### PR TITLE
feat(Result#changes) sort & group changes

### DIFF
--- a/lib/graphql/schema_comparator/result.rb
+++ b/lib/graphql/schema_comparator/result.rb
@@ -4,7 +4,7 @@ module GraphQL
       attr_reader :changes
 
       def initialize(changes)
-        @changes = changes
+        @changes = changes.sort_by { |c| [c.breaking ? 1 : 2, c.message] }
       end
 
       def identical?

--- a/test/lib/graphql/schema_comparator/result_test.rb
+++ b/test/lib/graphql/schema_comparator/result_test.rb
@@ -1,6 +1,16 @@
 require "test_helper"
 
 describe GraphQL::SchemaComparator::Result do
+  describe "#changes" do
+    it "returns sorted changes" do
+      removed_z = GraphQL::SchemaComparator::Changes::FieldRemoved.new(GraphQL::ObjectType.define(name: "Z"), GraphQL::Field.define(name: "a"))
+      removed_a = GraphQL::SchemaComparator::Changes::FieldRemoved.new(GraphQL::ObjectType.define(name: "A"), GraphQL::Field.define(name: "a"))
+      added_a = GraphQL::SchemaComparator::Changes::FieldAdded.new(GraphQL::ObjectType.define(name: "A"), GraphQL::Field.define(name: "a"))
+      result = GraphQL::SchemaComparator::Result.new([removed_z, added_a, removed_a])
+      assert_equal [removed_a, removed_z, added_a], result.changes
+    end
+  end
+
   describe "#identical?" do
     it "returns false when schemas have changes" do
       result = GraphQL::SchemaComparator::Result.new([

--- a/test/lib/graphql/schema_comparator_test.rb
+++ b/test/lib/graphql/schema_comparator_test.rb
@@ -36,8 +36,8 @@ describe GraphQL::SchemaComparator do
       result = GraphQL::SchemaComparator.compare(old_schema_idl, new_schema_idl)
 
       assert_equal [
+        "Field `Query.a` changed type from `String!` to `Int`",
         "Field `b` was added to object type `Query`",
-        "Field `Query.a` changed type from `String!` to `Int`"
       ], result.changes.map(&:message)
 
       assert_equal true, result.breaking?
@@ -47,8 +47,8 @@ describe GraphQL::SchemaComparator do
       result = GraphQL::SchemaComparator.compare(old_schema, new_schema)
 
       assert_equal [
+        "Field `Query.a` changed type from `String!` to `Int`",
         "Field `b` was added to object type `Query`",
-        "Field `Query.a` changed type from `String!` to `Int`"
       ], result.changes.map(&:message)
 
       assert_equal true, result.breaking?


### PR DESCRIPTION
I ran a really big diff and it was hard to make sense of the changes. What do you think of sorting the output? 

This approach is a bit simple: sort by breaking/non-breaking, then by message (which also groups them by type, since similar messages are sorted together). 

In the future, we could do even more with the output, for example:

- Group by type of change 
- Group by affected types/fields
- Add a concept of "priority", order by that (so that big breaking changes (eg type removed) come before small breaking changes (eg non-null field converted to nullable))

Do you think this is a good first step? Or are you interested in other ordered output possibilities?