### PR TITLE
feat(Result#non_breaking_changes) return list of non-breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ access information on the changes between the two schemas.
  - `result.breaking?` returns true if any breaking changes were found between the two schemas
  - `result.identical?` returns true if the two schemas were identical
  - `result.breaking_changes` returns the list of breaking changes found between schemas.
+ - `result.non_breaking_changes` returns the list of non-breaking changes found between schemas.
 - `result.changes` returns the full list of change objects.
 
 ### Change Objects

--- a/lib/graphql/schema_comparator/result.rb
+++ b/lib/graphql/schema_comparator/result.rb
@@ -1,22 +1,19 @@
 module GraphQL
   module SchemaComparator
     class Result
-      attr_reader :changes
+      attr_reader :changes, :breaking_changes, :non_breaking_changes
 
       def initialize(changes)
         @changes = changes
+        @breaking_changes, @non_breaking_changes = @changes.partition(&:breaking)
       end
 
       def identical?
         @changes.empty?
       end
 
-      def breaking_changes
-        @changes.select { |c| c.breaking }
-      end
-
       def breaking?
-        @changes.any? { |c| c.breaking }
+        breaking_changes.any?
       end
     end
   end

--- a/test/lib/graphql/schema_comparator/result_test.rb
+++ b/test/lib/graphql/schema_comparator/result_test.rb
@@ -31,7 +31,7 @@ describe GraphQL::SchemaComparator::Result do
     end
   end
 
-  describe "#breaking_changes" do
+  describe "#breaking_changes / #non_breaking_changes" do
     let(:field_added) {
       GraphQL::SchemaComparator::Changes::FieldAdded.new(GraphQL::ObjectType.new, GraphQL::Field.new)
     }
@@ -52,6 +52,7 @@ describe GraphQL::SchemaComparator::Result do
       ])
 
       assert_equal [field_removed], result.breaking_changes
+      assert_equal [field_added, type_description_changed], result.non_breaking_changes
     end
   end
 end


### PR DESCRIPTION
I was making some custom output that included a summary, with the count of breaking changes and the count of non-breaking changes. I added this method to print the summary, do you think it's useful here? 