### PR TITLE
fix(EnumValueRemoved) use an accurate message

### DIFF
--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -46,7 +46,7 @@ module GraphQL
       class EnumValueRemoved
         attr_reader :enum_value, :enum_type, :breaking
 
-        def initialize(enum_value, enum_type)
+        def initialize(enum_type, enum_value)
           @enum_value = enum_value
           @enum_type = enum_type
           @breaking = true

--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -53,7 +53,7 @@ module GraphQL
         end
 
         def message
-          "Enum Value #{enum_value.name} was removed from Enum #{enum_type.name}"
+          "Enum value `#{enum_value.name}` was removed from enum `#{enum_type.name}`"
         end
       end
 
@@ -197,7 +197,7 @@ module GraphQL
         end
 
         def message
-          "Enum value #{enum_value.name} was added on enum type #{enum_type.name}"
+          "Enum value `#{enum_value.name}` was added to enum `#{enum_type.name}`"
         end
       end
 

--- a/test/lib/graphql/schema_comparator/diff/schema_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/schema_test.rb
@@ -135,8 +135,8 @@ describe GraphQL::SchemaComparator::Diff::Schema do
         "Description for argument `a` on field `WithArguments.a` changed from `Meh` to `Description for a`",
         "Type for argument `b` on field `WithArguments.a` changed from `String` to `String!`",
         "Default value for argument `arg` on field `WithArguments.b` changed from `1` to `2`",
-        "Enum Value C was removed from Enum Options",
-        "Enum value D was added on enum type Options"
+        "Enum value `C` was removed from enum `Options`",
+        "Enum value `D` was added to enum `Options`"
       ], differ.diff.map(&:message)
     end
   end

--- a/test/lib/graphql/schema_comparator/diff/schema_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/schema_test.rb
@@ -43,6 +43,11 @@ describe GraphQL::SchemaComparator::Diff::Schema do
           ): String
           b(arg: Int = 1): String
         }
+        enum Options {
+          A
+          B
+          C
+        }
       SCHEMA
     )
   end
@@ -92,6 +97,11 @@ describe GraphQL::SchemaComparator::Diff::Schema do
           ): String
           b(arg: Int = 2): String
         }
+        enum Options {
+          A
+          B
+          D
+        }
       SCHEMA
     )
   end
@@ -125,6 +135,8 @@ describe GraphQL::SchemaComparator::Diff::Schema do
         "Description for argument `a` on field `WithArguments.a` changed from `Meh` to `Description for a`",
         "Type for argument `b` on field `WithArguments.a` changed from `String` to `String!`",
         "Default value for argument `arg` on field `WithArguments.b` changed from `1` to `2`",
+        "Enum Value C was removed from Enum Options",
+        "Enum value D was added on enum type Options"
       ], differ.diff.map(&:message)
     end
   end


### PR DESCRIPTION
Oopsie, the `initialize` parameters were reversed, so it was printing a backwards message, eg: 

```diff 
  Previously:
- Enum Value Options was removed from Enum C
  Now: 
+ Enum Value C was removed from Enum Options 
```

In the first commit, I reversed the parameters in `#initialize` and added a test. In the second commit, I made the two messages match. How do these look?