### PR TITLE
Add some backticks to breaking changes messages

### DIFF
--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -12,7 +12,7 @@ module GraphQL
         end
 
         def message
-          "#{removed_type.name} was removed"
+          "`#{removed_type.name}` was removed"
         end
       end
 
@@ -25,7 +25,7 @@ module GraphQL
         end
 
         def message
-          "#{removed_directive.name} was removed"
+          "`#{removed_directive.name}` was removed"
         end
       end
 


### PR DESCRIPTION
I noticed a couple of these messages were missing the backticks around the code names, so I added them. 