### PR TITLE
Update field type change breaking

### DIFF
--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -834,7 +834,7 @@ module GraphQL
         end
 
         def message
-          "Input field `#{input_type}.#{old_input_field.name}` changed type from #{old_input_field.type} to #{new_input_field.type}"
+          "Input field `#{input_type}.#{old_input_field.name}` changed type from `#{old_input_field.type}` to `#{new_input_field.type}`"
         end
 
         def breaking?

--- a/test/lib/graphql/schema_comparator/diff/field_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/field_test.rb
@@ -1,0 +1,175 @@
+require "test_helper"
+
+describe GraphQL::SchemaComparator::Diff::Field do
+  let(:type) do
+    GraphQL::ObjectType.define do
+      name "Foo"
+    end
+  end
+
+  let(:differ) { GraphQL::SchemaComparator::Diff::Field.new(type, type, old_field, new_field) }
+  let(:changes) { differ.diff }
+  let(:change) { differ.diff.first }
+
+  describe "#diff" do
+    describe "field type change" do
+      let(:old_field) do
+        GraphQL::Field.define do
+          name "foo"
+          type types.String
+        end
+      end
+
+      let(:new_field) do
+        old_field.redefine { type types.Boolean }
+      end
+
+      it "is a breaking change" do
+        assert_equal 1, changes.size
+        assert change.breaking?
+
+        assert_equal "Field `Foo.foo` changed type from `String` to `Boolean`", change.message
+      end
+    end
+
+    describe "field type change from scalar to list of the same type" do
+      let(:old_field) do
+        GraphQL::Field.define do
+          name "bar"
+          type types[types.String]
+        end
+      end
+
+      let(:new_field) do
+        old_field.redefine { type types.String }
+      end
+
+      it "is a non-breaking change" do
+        assert_equal 1, changes.size
+        assert change.breaking?
+
+        assert_equal "Field `Foo.bar` changed type from `[String]` to `String`", change.message
+      end
+    end
+
+    describe "field type change from non-null to null of the same underyling type" do
+      let(:old_field) do
+        GraphQL::Field.define do
+          name "bar"
+          type !types.String
+        end
+      end
+
+      let(:new_field) do
+        old_field.redefine { type types.String }
+      end
+
+      it "is a breaking change" do
+        assert_equal 1, changes.size
+        assert change.breaking?
+
+        assert_equal "Field `Foo.bar` changed type from `String!` to `String`", change.message
+      end
+    end
+
+    describe "field type change from null to non-null of the same underyling type" do
+      let(:old_field) do
+        GraphQL::Field.define do
+          name "bar"
+          type types.String
+        end
+      end
+
+      let(:new_field) do
+        old_field.redefine { type !types.String }
+      end
+
+      it "is a non-breaking change" do
+        assert_equal 1, changes.size
+        refute change.breaking?
+
+        assert_equal "Field `Foo.bar` changed type from `String` to `String!`", change.message
+      end
+    end
+
+    describe "field type nullability change on lists of the same underlying types" do
+      let(:old_field) do
+        GraphQL::Field.define do
+          name "bar"
+          type !types[types.String]
+        end
+      end
+
+      let(:new_field) do
+        old_field.redefine { type types[types.String] }
+      end
+
+      it "is a breaking chnage" do
+        assert_equal 1, changes.size
+        assert change.breaking?
+
+        assert_equal "Field `Foo.bar` changed type from `[String]!` to `[String]`", change.message
+      end
+    end
+
+    describe "field type change within lists of the same underyling types" do
+      let(:old_field) do
+        GraphQL::Field.define do
+          name "bar"
+          type !types[!types.String]
+        end
+      end
+
+      let(:new_field) do
+        old_field.redefine { type !types[types.String] }
+      end
+
+      it "is a breaking change" do
+        assert_equal 1, changes.size
+        assert change.breaking?
+
+        assert_equal "Field `Foo.bar` changed type from `[String!]!` to `[String]!`", change.message
+      end
+    end
+
+    describe "field type changes on and within lists of the same underlying types" do
+      let(:old_field) do
+        GraphQL::Field.define do
+          name "bar"
+          type !types[!types.String]
+        end
+      end
+
+      let(:new_field) do
+        old_field.redefine { type types[types.String] }
+      end
+
+      it "is a breaking change" do
+        assert_equal 1, changes.size
+        assert change.breaking?
+
+        assert_equal "Field `Foo.bar` changed type from `[String!]!` to `[String]`", change.message
+      end
+    end
+
+    describe "field type changes on and within lists of different underlying types" do
+      let(:old_field) do
+        GraphQL::Field.define do
+          name "bar"
+          type !types[!types.String]
+        end
+      end
+
+      let(:new_field) do
+        old_field.redefine { type types[types.Boolean] }
+      end
+
+      it "is a breaking change" do
+        assert_equal 1, changes.size
+        assert change.breaking?
+
+        assert_equal "Field `Foo.bar` changed type from `[String!]!` to `[Boolean]`", change.message
+      end
+    end
+  end
+end

--- a/test/lib/graphql/schema_comparator/diff/input_field_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/input_field_test.rb
@@ -28,7 +28,7 @@ describe GraphQL::SchemaComparator::Diff::InputField do
         assert_equal 1, changes.size
         assert change.breaking?
 
-        assert_equal "Input field `Input.foo` changed type from String to Boolean", change.message
+        assert_equal "Input field `Input.foo` changed type from `String` to `Boolean`", change.message
       end
     end
 
@@ -48,7 +48,7 @@ describe GraphQL::SchemaComparator::Diff::InputField do
         assert_equal 1, changes.size
         assert change.breaking?
 
-        assert_equal "Input field `Input.arg` changed type from [String] to String", change.message
+        assert_equal "Input field `Input.arg` changed type from `[String]` to `String`", change.message
       end
     end
 
@@ -68,7 +68,7 @@ describe GraphQL::SchemaComparator::Diff::InputField do
         assert_equal 1, changes.size
         refute change.breaking?
 
-        assert_equal "Input field `Input.arg` changed type from String! to String", change.message
+        assert_equal "Input field `Input.arg` changed type from `String!` to `String`", change.message
       end
     end
 
@@ -87,7 +87,7 @@ describe GraphQL::SchemaComparator::Diff::InputField do
       it "is a breaking change" do
         assert change.breaking?
         assert_equal 1, changes.size
-        assert_equal "Input field `Input.arg` changed type from String to String!", change.message
+        assert_equal "Input field `Input.arg` changed type from `String` to `String!`", change.message
       end
     end
 
@@ -107,7 +107,7 @@ describe GraphQL::SchemaComparator::Diff::InputField do
         assert_equal 1, changes.size
         refute change.breaking?
 
-        assert_equal "Input field `Input.arg` changed type from [String]! to [String]", change.message
+        assert_equal "Input field `Input.arg` changed type from `[String]!` to `[String]`", change.message
       end
     end
 
@@ -127,7 +127,7 @@ describe GraphQL::SchemaComparator::Diff::InputField do
         assert_equal 1, changes.size
         refute change.breaking?
 
-        assert_equal "Input field `Input.arg` changed type from [String!]! to [String]!", change.message
+        assert_equal "Input field `Input.arg` changed type from `[String!]!` to `[String]!`", change.message
       end
     end
 
@@ -147,7 +147,7 @@ describe GraphQL::SchemaComparator::Diff::InputField do
         assert_equal 1, changes.size
         refute change.breaking?
 
-        assert_equal "Input field `Input.arg` changed type from [String!]! to [String]", change.message
+        assert_equal "Input field `Input.arg` changed type from `[String!]!` to `[String]`", change.message
       end
     end
 
@@ -167,7 +167,7 @@ describe GraphQL::SchemaComparator::Diff::InputField do
         assert_equal 1, changes.size
         assert change.breaking?
 
-        assert_equal "Input field `Input.arg` changed type from [String!]! to [Boolean]", change.message
+        assert_equal "Input field `Input.arg` changed type from `[String!]!` to `[Boolean]`", change.message
       end
     end
   end

--- a/test/lib/graphql/schema_comparator/diff/schema_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/schema_test.rb
@@ -136,7 +136,7 @@ describe GraphQL::SchemaComparator::Diff::Schema do
         "Input field `c` was added to input object type `AInput`",
         "Input field `AInput.a` description changed from `a` to `changed`",
         "Input field `AInput.a` default changed from `1` to `1`",
-        "Input field `AInput.a` changed type from String to Int",
+        "Input field `AInput.a` changed type from `String` to `Int`",
         "`CType` object implements `AnInterface` interface",
         "Field `c` was removed from object type `CType`",
         "Field `b` was added to object type `CType`",


### PR DESCRIPTION
Similar to https://github.com/xuorig/graphql-schema_comparator/pull/12, but for object and interface field type changes.

Once again this is based on the JS packge: https://github.com/graphql/graphql-js/blob/fed3ef58fde674fa96d79879eb4dfc24a0ba1db0/src/utilities/findBreakingChanges.js#L399-L442