### PR TITLE
Bundler is required for `schema_comparator` to run

### DIFF
--- a/graphql-schema_comparator.gemspec
+++ b/graphql-schema_comparator.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "graphql", "~> 1.6"
   spec.add_dependency "thor", "~> 0.19"
+  spec.add_dependency "bundler", "~> 1.14"
 
-  spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.10"
   spec.add_development_dependency "pry-byebug", "~> 3.4"


### PR DESCRIPTION
This means it is not a development dependency, but rather a full install dependency.