### PR TITLE
Return exit code if there is a breaking change

### DIFF
--- a/bin/schema_comparator
+++ b/bin/schema_comparator
@@ -22,6 +22,9 @@ class GraphQLSchema < Thor
     else
       print_changes(result)
     end
+
+    exit_code = result.breaking? ? 1 : 0
+    exit(exit_code)
   end
 
   private


### PR DESCRIPTION
I'd like to run this in our CI pipeline to prevent breaking changes being merged.

This change returns a non-zero exit code if there are breaking changes, which will cause a CI pipeline looking at exit codes to fail.