### PR TITLE
Relax thor dependency

### DIFF
--- a/graphql-schema_comparator.gemspec
+++ b/graphql-schema_comparator.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "graphql", "~> 1.6"
-  spec.add_dependency "thor", "~> 0.19"
+  spec.add_dependency "thor", ">= 0.19", "< 2.0"
   spec.add_dependency "bundler", "~> 1.14"
 
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
I used < 2.0 because that's what Rails uses. Happy to make the high end more strict as long as we can support 0.20+. Thanks!

---

Rails 6.0 Railties requires thor set to
`s.add_dependency "thor", ">= 0.20.3", "< 2.0"` and currently this gem
won't allow anything higher than 0.19.x. See
https://github.com/rails/rails/blob/master/railties/railties.gemspec#L40

This PR relaxes the thor dependency so that this gem can be used with
applications running or upgrading to Rails 6+.

cc/ @xuorig 