### PR TITLE
Add "verify" command for CI usage

### DIFF
--- a/bin/schema_comparator
+++ b/bin/schema_comparator
@@ -5,9 +5,23 @@ require "thor"
 require "graphql/schema_comparator"
 
 class GraphQLSchema < Thor
+  desc "verify OLD_SCHEMA NEW_SCHEMA", "Behaves exactly like `compare` but returns an exit code for CI purposes"
+
+  def verify(old_schema, new_schema)
+    result = run_compare(old_schema, new_schema)
+    exit_code = result.breaking? ? 1 : 0
+    exit(exit_code)
+  end
+
   desc "compare OLD_SCHEMA NEW_SCHEMA", "Compares OLD_SCHEMA with NEW_SCHEMA and returns a list of changes"
 
   def compare(old_schema, new_schema)
+    run_compare(old_schema, new_schema)
+  end
+
+  private
+
+  def run_compare(old_schema, new_schema)
     parsed_old = parse_schema(old_schema)
     parsed_new = parse_schema(new_schema)
 
@@ -22,9 +36,8 @@ class GraphQLSchema < Thor
     else
       print_changes(result)
     end
+    result
   end
-
-  private
 
   def print_changes(result)
     say "Detected the following changes between schemas:"

--- a/lib/graphql/schema_comparator/version.rb
+++ b/lib/graphql/schema_comparator/version.rb
@@ -1,5 +1,5 @@
 module GraphQL
   module SchemaComparator
-    VERSION = "0.6.0"
+    VERSION = "0.6.1"
   end
 end


### PR DESCRIPTION
Related: https://github.com/xuorig/graphql-schema_comparator/pull/20

For CI usage, returning a non-zero exit code for breaking changes is useful. So what I'm doing here is creating a new `verify` command that behaves just like `compare` but includes the exit code.