### PR TITLE
Allow for Backwards Compatibility with Bundler 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 cache: bundler
 before_install:
   - gem update --system --no-doc
-  - gem install bundler
+  - gem install bundler -v 1.1.4
 rvm:
 - 2.3.4
 - 2.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 cache: bundler
 before_install:
   - gem update --system --no-doc
-  - gem install bundler -v 1.1.4
+  - gem install bundler
 rvm:
 - 2.3.4
 - 2.4.1

--- a/graphql-schema_comparator.gemspec
+++ b/graphql-schema_comparator.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "graphql", "~> 1.6"
   spec.add_dependency "thor", ">= 0.19", "< 2.0"
-  spec.add_dependency "bundler", "~> 1.14"
+  spec.add_dependency "bundler", ">= 1.14"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.10"

--- a/graphql-schema_comparator.gemspec
+++ b/graphql-schema_comparator.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "graphql", "~> 1.6"
   spec.add_dependency "thor", ">= 0.19", "< 2.0"
-  spec.add_dependency "bundler", "~> 2.0.1"
+  spec.add_dependency "bundler", "~> 1.14"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
In case a project pinned to bundler 1.x for other reasons can still use later versions of this gem.

Basically just used `>= 1.14` so that projects _can_ use latest bundler but do not have to. This in and of itself was enough to get CI builds to pass - this project does not appear to actually require the latest version of bundler. So in order for this gem to play nice with the greatest possible number of projects, I'd recommend this change be merged if possible.