### PR TITLE
Fix directives

### DIFF
--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -502,7 +502,7 @@ module GraphQL
 
         def message
           "Default value for argument `#{new_argument.graphql_name}` on directive `#{directive.graphql_name}` changed"\
-            " from `#{old_argument.ast_node.default_value}` to `#{new_argument.ast_node.default_value}`"
+            " from `#{old_argument.default_value}` to `#{new_argument.default_value}`"
         end
 
         def path

--- a/lib/graphql/schema_comparator/diff/directive_argument.rb
+++ b/lib/graphql/schema_comparator/diff/directive_argument.rb
@@ -19,7 +19,7 @@ module GraphQL
             changes << Changes::DirectiveArgumentDefaultChanged.new(directive, old_arg, new_arg)
           end
 
-          if old_arg.type != new_arg.type
+          if old_arg.type.graphql_definition != new_arg.type.graphql_definition
             changes << Changes::DirectiveArgumentTypeChanged.new(directive, old_arg, new_arg)
           end
 


### PR DESCRIPTION
- don't crash generating messages for default values
- compare types properly

I didn't add tests because the existing test file for directives
is already broken and disabled for some reason.

@xuorig cc @cocoahero

@swalkinshaw 