### PR TITLE
Run tests against pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: Tests
 
 on:
-  push
+  - push
+  - pull_request
 
 jobs:
   test:


### PR DESCRIPTION
 I noticed that no CI ran against #38 so this PR updates the GitHub CI workflow to run against pushes and pull requests.

/cc @swalkinshaw 