### PR TITLE
Fix typos

### DIFF
--- a/lib/graphql/schema_comparator/changes/criticality.rb
+++ b/lib/graphql/schema_comparator/changes/criticality.rb
@@ -14,7 +14,7 @@ module GraphQL
         # these changes.
         DANGEROUS = 2
 
-        # Breaking criticality are changes that immediatly impact
+        # Breaking criticality are changes that immediately impact
         # clients usually causing queries not to be valid anymore.
         BREAKING = 3
 

--- a/test/lib/graphql/schema_comparator/diff/argument_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/argument_test.rb
@@ -100,7 +100,7 @@ class GraphQL::SchemaComparator::Diff::ArgumentTest < Minitest::Test
     assert_equal "Type for argument `arg` on field `Query.a` changed from `[String]!` to `[String]`", change.message
   end
 
-  def test_diff_input_field_type_change_within_lists_of_the_same_underyling_types
+  def test_diff_input_field_type_change_within_lists_of_the_same_underlying_types
     old_input_field = GraphQL::Argument.define do
       name "arg"
       type !types[!types.String]

--- a/test/lib/graphql/schema_comparator/diff/field_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/field_test.rb
@@ -97,7 +97,7 @@ class GraphQL::SchemaComparator::Diff::FieldTest < Minitest::Test
     assert_equal "Field `Foo.bar` changed type from `[String]!` to `[String]`", change.message
   end
 
-  def test_field_type_change_withing_lists_of_the_same_underlying_types
+  def test_field_type_change_within_lists_of_the_same_underlying_types
     old_field = GraphQL::Field.define do
       name "bar"
       type !types[!types.String]
@@ -115,7 +115,7 @@ class GraphQL::SchemaComparator::Diff::FieldTest < Minitest::Test
     assert_equal "Field `Foo.bar` changed type from `[String!]!` to `[String]!`", change.message
   end
 
-  def test_field_type_change_withing_and_on_list_of_same_type
+  def test_field_type_change_within_and_on_list_of_same_type
     old_field = GraphQL::Field.define do
       name "bar"
       type !types[!types.String]
@@ -133,7 +133,7 @@ class GraphQL::SchemaComparator::Diff::FieldTest < Minitest::Test
     assert_equal "Field `Foo.bar` changed type from `[String!]!` to `[String]`", change.message
   end
 
-  def test_field_type_change_withing_and_on_list_of_same_type_of_different_types
+  def test_field_type_change_within_and_on_list_of_same_type_of_different_types
     old_field = GraphQL::Field.define do
       name "bar"
       type !types[!types.String]

--- a/test/lib/graphql/schema_comparator/diff/input_field_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/input_field_test.rb
@@ -97,7 +97,7 @@ class GraphQL::SchemaComparator::Diff::InputFieldTest < Minitest::Test
     assert_equal "Input field `Input.arg` changed type from `[String]!` to `[String]`", change.message
   end
 
-  def test_diff_input_field_type_change_within_lists_of_the_same_underyling_types
+  def test_diff_input_field_type_change_within_lists_of_the_same_underlying_types
     old_input_field = GraphQL::Argument.define do
       name "arg"
       type !types[!types.String]


### PR DESCRIPTION
This fixes various typos in comments and test names, which I found while working on some other stuff.