### PR TITLE
Consider `id` field addition dangerous

### DIFF
--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -843,7 +843,11 @@ module GraphQL
         attr_reader :object_type, :field, :criticality
 
         def initialize(object_type, field)
-          @criticality = Changes::Criticality.non_breaking
+          @criticality = if field.graphql_name == 'id'
+                           Changes::Criticality.dangerous('this can blow up linters and change caching behaviour')
+                         else
+                           Changes::Criticality.non_breaking
+                         end
           @object_type = object_type
           @field = field
         end

--- a/test/lib/graphql/schema_comparator/changes/field_added_test.rb
+++ b/test/lib/graphql/schema_comparator/changes/field_added_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class GraphQL::SchemaComparator::Changes::FieldAddedTest < Minitest::Test
+  def test_criticality_is_non_breaking_by_default
+    change = GraphQL::SchemaComparator::Changes::FieldAdded.new(
+      GraphQL::ObjectType.define { name "Type" },
+      GraphQL::Field.define { name "field" },
+    )
+
+    assert change.non_breaking?
+  end
+
+  def test_criticality_is_non_breaking_for_id_field_addition
+    change = GraphQL::SchemaComparator::Changes::FieldAdded.new(
+      GraphQL::ObjectType.define { name "Type" },
+      GraphQL::Field.define { name "id" },
+    )
+
+    assert change.non_breaking?
+  end
+end

--- a/test/lib/graphql/schema_comparator/changes/field_added_test.rb
+++ b/test/lib/graphql/schema_comparator/changes/field_added_test.rb
@@ -10,12 +10,13 @@ class GraphQL::SchemaComparator::Changes::FieldAddedTest < Minitest::Test
     assert change.non_breaking?
   end
 
-  def test_criticality_is_non_breaking_for_id_field_addition
+  def test_criticality_is_dangerous_for_id_field_addition
     change = GraphQL::SchemaComparator::Changes::FieldAdded.new(
       GraphQL::ObjectType.define { name "Type" },
       GraphQL::Field.define { name "id" },
     )
 
-    assert change.non_breaking?
+    assert change.dangerous?
+    assert_equal 'this can blow up linters and change caching behaviour', change.message
   end
 end


### PR DESCRIPTION
While most of the time adding a field is a safe non-breaking change, there are certain fields that can be dangerous to add, **namely the `id` field**.

This is because many caching implementations will use the `id` field as part of a cache key, if present. For example, Apollo's `InMemoryCache` uses `__typename` and `id` (or `_id`) to generate a cache key.[^1]

In fact, an ESLint-Plugin-GraphQL rule exists to enforce the querying of so called "required fields"[^2] (such as `id`), to ensure caching is done properly.

As such, adding an `id` field to an existing type can change the client side caching behaviour if the client hasn't defined a custom caching strategy (e.g. start caching resources that were previously not cached).

[^1]:https://www.apollographql.com/docs/react/v2/caching/cache-configuration/#default-identifiers

[^2]:https://github.com/apollographql/eslint-plugin-graphql#required-fields-validation-rule