### PR TITLE
Refactor legacy graphql API usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,13 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.4, 2.7, '3.0']
+        gemfile: [graphql1.10, graphql1.13, graphql-head]
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
         ruby-version: ${{ matrix.ruby }}
-    - run: bundle install
     - run: bundle exec rake

--- a/gemfiles/graphql-head.gemfile
+++ b/gemfiles/graphql-head.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "graphql", "~> 1.13", "< 3.0"
+
+gemspec path: "../"

--- a/gemfiles/graphql1.10.gemfile
+++ b/gemfiles/graphql1.10.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "graphql", "~> 1.10.0"
+
+gemspec path: "../"

--- a/gemfiles/graphql1.13.gemfile
+++ b/gemfiles/graphql1.13.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "graphql", "~> 1.13.0"
+
+gemspec path: "../"

--- a/graphql-schema_comparator.gemspec
+++ b/graphql-schema_comparator.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ["graphql-schema", "schema_comparator"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "graphql", "~> 1.10"
+  spec.add_dependency "graphql", ">= 1.10", "< 3.0"
   spec.add_dependency "thor", ">= 0.19", "< 2.0"
   spec.add_dependency "bundler", ">= 1.14"
 

--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -51,11 +51,11 @@ module GraphQL
         end
 
         def message
-          "Type `#{removed_type.graphql_definition}` was removed"
+          "Type `#{removed_type.graphql_name}` was removed"
         end
 
         def path
-          removed_type.graphql_definition.to_s
+          removed_type.path
         end
       end
 
@@ -88,11 +88,11 @@ module GraphQL
         end
 
         def message
-          "`#{old_type.graphql_definition}` kind changed from `#{old_type.kind}` to `#{new_type.kind}`"
+          "`#{old_type.graphql_name}` kind changed from `#{old_type.kind}` to `#{new_type.kind}`"
         end
 
         def path
-          old_type.graphql_definition.to_s
+          old_type.path
         end
       end
 
@@ -108,11 +108,11 @@ module GraphQL
         end
 
         def message
-          "Enum value `#{enum_value.graphql_name}` was removed from enum `#{enum_type.graphql_definition}`"
+          "Enum value `#{enum_value.graphql_name}` was removed from enum `#{enum_type.graphql_name}`"
         end
 
         def path
-          [enum_type.graphql_definition, enum_value.graphql_name].join('.')
+          enum_value.path
         end
       end
 
@@ -128,11 +128,11 @@ module GraphQL
         end
 
         def message
-          "Union member `#{union_member.graphql_name}` was removed from Union type `#{union_type.graphql_definition}`"
+          "Union member `#{union_member.graphql_name}` was removed from Union type `#{union_type.graphql_name}`"
         end
 
         def path
-          union_type.graphql_definition.to_s
+          union_type.path
         end
       end
 
@@ -148,11 +148,11 @@ module GraphQL
         end
 
         def message
-          "Input field `#{field.graphql_name}` was removed from input object type `#{input_object_type.graphql_definition}`"
+          "Input field `#{field.graphql_name}` was removed from input object type `#{input_object_type.graphql_name}`"
         end
 
         def path
-          [input_object_type.graphql_definition, field.graphql_name].join('.')
+          field.path
         end
       end
 
@@ -169,11 +169,11 @@ module GraphQL
         end
 
         def message
-          "Argument `#{argument.graphql_name}: #{argument.type.graphql_definition}` was removed from field `#{object_type.graphql_definition}.#{field.graphql_name}`"
+          "Argument `#{argument.graphql_name}: #{argument.type.graphql_name}` was removed from field `#{object_type.graphql_name}.#{field.graphql_name}`"
         end
 
         def path
-          [object_type.graphql_definition, field.graphql_name, argument.graphql_name].join('.')
+          argument.path
         end
       end
 
@@ -233,11 +233,11 @@ module GraphQL
         end
 
         def message
-          "Field `#{field.graphql_name}` was removed from object type `#{object_type.graphql_definition}`"
+          "Field `#{field.graphql_name}` was removed from object type `#{object_type.graphql_name}`"
         end
 
         def path
-          [object_type.graphql_definition, field.graphql_name].join('.')
+          [object_type.graphql_name, field.graphql_name].join(".")
         end
       end
 
@@ -271,11 +271,11 @@ module GraphQL
         end
 
         def message
-          "`#{object_type.graphql_definition}` object type no longer implements `#{interface.graphql_name}` interface"
+          "`#{object_type.graphql_name}` object type no longer implements `#{interface.graphql_name}` interface"
         end
 
         def path
-          object_type.graphql_definition.to_s
+          object_type.path
         end
       end
 
@@ -291,7 +291,7 @@ module GraphQL
         end
 
         def message
-          "Field `#{type.graphql_definition}.#{old_field.graphql_name}` changed type from `#{old_field.type.graphql_definition}` to `#{new_field.type.graphql_definition}`"
+          "Field `#{old_field.path}` changed type from `#{old_field.type.to_type_signature}` to `#{new_field.type.to_type_signature}`"
         end
 
         def criticality
@@ -303,7 +303,7 @@ module GraphQL
         end
 
         def path
-          [type.graphql_definition, old_field.graphql_name].join('.')
+          old_field.path
         end
       end
 
@@ -329,11 +329,11 @@ module GraphQL
         end
 
         def message
-          "Input field `#{input_type.graphql_definition}.#{old_input_field.graphql_name}` changed type from `#{old_input_field.type.graphql_definition}` to `#{new_input_field.type.graphql_definition}`"
+          "Input field `#{path}` changed type from `#{old_input_field.type.to_type_signature}` to `#{new_input_field.type.to_type_signature}`"
         end
 
         def path
-          [input_type.graphql_definition, old_input_field.graphql_name].join('.')
+          old_input_field.path
         end
       end
 
@@ -360,12 +360,12 @@ module GraphQL
         end
 
         def message
-          "Type for argument `#{new_argument.graphql_name}` on field `#{type.graphql_definition}.#{field.graphql_definition.name}` changed"\
-            " from `#{old_argument.type.graphql_definition}` to `#{new_argument.type.graphql_definition}`"
+          "Type for argument `#{new_argument.graphql_name}` on field `#{field.path}` changed"\
+            " from `#{old_argument.type.to_type_signature}` to `#{new_argument.type.to_type_signature}`"
         end
 
         def path
-          [type.graphql_definition, field.graphql_definition.name, old_argument.graphql_name].join('.')
+          old_argument.path
         end
       end
 
@@ -390,7 +390,7 @@ module GraphQL
 
         def message
           "Type for argument `#{new_argument.graphql_name}` on directive `#{directive.graphql_name}` changed"\
-            " from `#{old_argument.type.graphql_definition}` to `#{new_argument.type.graphql_definition}`"
+            " from `#{old_argument.type.to_type_signature}` to `#{new_argument.type.to_type_signature}`"
         end
 
         def path
@@ -452,15 +452,15 @@ module GraphQL
 
         def message
           if old_argument.default_value.nil? || old_argument.default_value == :__no_default__
-            "Default value `#{new_argument.default_value}` was added to argument `#{new_argument.graphql_name}` on field `#{type.graphql_definition}.#{field.graphql_name}`"
+            "Default value `#{new_argument.default_value}` was added to argument `#{new_argument.graphql_name}` on field `#{field.path}`"
           else
-            "Default value for argument `#{new_argument.graphql_name}` on field `#{type.graphql_definition}.#{field.name}` changed"\
+            "Default value for argument `#{new_argument.graphql_name}` on field `#{field.path}` changed"\
               " from `#{old_argument.default_value}` to `#{new_argument.default_value}`"
           end
         end
 
         def path
-          [type.graphql_definition, field.graphql_name, old_argument.graphql_name].join('.')
+          old_argument.path
         end
       end
 
@@ -478,12 +478,12 @@ module GraphQL
         end
 
         def message
-          "Input field `#{input_type.graphql_definition}.#{old_field.graphql_name}` default changed"\
+          "Input field `#{path}` default changed"\
             " from `#{old_field.default_value}` to `#{new_field.default_value}`"
         end
 
         def path
-          [input_type.graphql_definition, old_field.graphql_name].join(".")
+          old_field.path
         end
       end
 
@@ -523,11 +523,11 @@ module GraphQL
         end
 
         def message
-          "Enum value `#{enum_value.graphql_name}` was added to enum `#{enum_type.graphql_definition}`"
+          "Enum value `#{enum_value.graphql_name}` was added to enum `#{enum_type.graphql_name}`"
         end
 
         def path
-          [enum_type.graphql_definition, enum_value.graphql_name].join(".")
+          enum_value.path
         end
       end
 
@@ -544,11 +544,11 @@ module GraphQL
         end
 
         def message
-          "Union member `#{union_member.graphql_name}` was added to Union type `#{union_type.graphql_definition}`"
+          "Union member `#{union_member.graphql_name}` was added to Union type `#{union_type.graphql_name}`"
         end
 
         def path
-          union_type.graphql_definition.to_s
+          union_type.path
         end
       end
 
@@ -565,11 +565,11 @@ module GraphQL
         end
 
         def message
-          "`#{object_type.graphql_definition}` object implements `#{interface.graphql_name}` interface"
+          "`#{object_type.graphql_name}` object implements `#{interface.graphql_name}` interface"
         end
 
         def path
-          object_type.graphql_definition.to_s
+          object_type.path
         end
       end
 
@@ -590,11 +590,11 @@ module GraphQL
         end
 
         def message
-          "Input field `#{field.graphql_name}` was added to input object type `#{input_object_type.graphql_definition}`"
+          "Input field `#{field.graphql_name}` was added to input object type `#{input_object_type.graphql_name}`"
         end
 
         def path
-          [input_object_type.graphql_definition, field.graphql_name].join(".")
+          field.path
         end
       end
 
@@ -614,11 +614,11 @@ module GraphQL
         end
 
         def message
-          "Argument `#{argument.graphql_name}: #{argument.type.graphql_definition}` added to field `#{type.graphql_definition}.#{field.graphql_name}`"
+          "Argument `#{argument.graphql_name}: #{argument.type.graphql_name}` added to field `#{field.path}`"
         end
 
         def path
-          [type.graphql_definition, field.graphql_name, argument.graphql_name].join(".")
+          argument.path
         end
       end
 
@@ -631,11 +631,11 @@ module GraphQL
         end
 
         def message
-          "Type `#{type.graphql_definition}` was added"
+          "Type `#{type.graphql_name}` was added"
         end
 
         def path
-          type.graphql_definition.to_s
+          type.path
         end
       end
 
@@ -666,11 +666,11 @@ module GraphQL
         end
 
         def message
-          "Description `#{old_type.description}` on type `#{old_type.graphql_definition}` has changed to `#{new_type.description}`"
+          "Description `#{old_type.description}` on type `#{old_type.graphql_name}` has changed to `#{new_type.description}`"
         end
 
         def path
-          old_type.graphql_definition.to_s
+          old_type.path
         end
       end
 
@@ -685,12 +685,12 @@ module GraphQL
         end
 
         def message
-          "Description for enum value `#{enum.graphql_name}.#{new_enum_value.graphql_name}` changed from " \
+          "Description for enum value `#{new_enum_value.path}` changed from " \
             "`#{old_enum_value.description}` to `#{new_enum_value.description}`"
         end
 
         def path
-          [enum.graphql_name, old_enum_value.graphql_name].join(".")
+          old_enum_value.path
         end
       end
 
@@ -706,16 +706,15 @@ module GraphQL
 
         def message
           if old_enum_value.deprecation_reason
-            "Enum value `#{enum.graphql_name}.#{new_enum_value.graphql_name}` deprecation reason changed " \
+            "Enum value `#{new_enum_value.path}` deprecation reason changed " \
               "from `#{old_enum_value.deprecation_reason}` to `#{new_enum_value.deprecation_reason}`"
           else
-            "Enum value `#{enum.graphql_name}.#{new_enum_value.graphql_name}` was deprecated with reason" \
-              " `#{new_enum_value.deprecation_reason}`"
+            "Enum value `#{new_enum_value.path}` was deprecated with reason `#{new_enum_value.deprecation_reason}`"
           end
         end
 
         def path
-          [enum.graphql_name, old_enum_value.graphql_name].join(".")
+          old_enum_value.path
         end
       end
 
@@ -730,12 +729,12 @@ module GraphQL
         end
 
         def message
-          "Input field `#{input_type.graphql_definition}.#{old_field.graphql_name}` description changed"\
+          "Input field `#{old_field.path}` description changed"\
             " from `#{old_field.description}` to `#{new_field.description}`"
         end
 
         def path
-          [input_type.graphql_definition, old_field.graphql_name].join(".")
+          old_field.path
         end
       end
 
@@ -769,12 +768,12 @@ module GraphQL
         end
 
         def message
-          "Field `#{type.graphql_definition}.#{old_field.graphql_name}` description changed"\
+          "Field `#{old_field.path}` description changed"\
             " from `#{old_field.description}` to `#{new_field.description}`"
         end
 
         def path
-          [type.graphql_definition, old_field.graphql_name].join(".")
+          old_field.path
         end
       end
 
@@ -790,12 +789,12 @@ module GraphQL
         end
 
         def message
-          "Description for argument `#{new_argument.graphql_name}` on field `#{type.graphql_definition}.#{field.graphql_name}` changed"\
+          "Description for argument `#{new_argument.graphql_name}` on field `#{field.path}` changed"\
             " from `#{old_argument.description}` to `#{new_argument.description}`"
         end
 
         def path
-          [type.graphql_definition, field.graphql_name, old_argument.graphql_name].join(".")
+          old_argument.path
         end
       end
 
@@ -830,12 +829,12 @@ module GraphQL
         end
 
         def message
-          "Deprecation reason on field `#{type.graphql_definition}.#{new_field.graphql_name}` has changed "\
+          "Deprecation reason on field `#{new_field.path}` has changed "\
             "from `#{old_field.deprecation_reason}` to `#{new_field.deprecation_reason}`"
         end
 
         def path
-          [type.graphql_definition, old_field.graphql_name].join(".")
+          old_field.path
         end
       end
 
@@ -849,11 +848,11 @@ module GraphQL
         end
 
         def message
-          "Field `#{field.graphql_name}` was added to object type `#{object_type.graphql_definition}`"
+          "Field `#{field.graphql_name}` was added to object type `#{object_type.graphql_name}`"
         end
 
         def path
-          [object_type.graphql_definition, field.graphql_name].join(".")
+          [object_type.graphql_name, field.graphql_name].join(".")
         end
       end
 

--- a/lib/graphql/schema_comparator/diff/argument.rb
+++ b/lib/graphql/schema_comparator/diff/argument.rb
@@ -21,7 +21,7 @@ module GraphQL
             changes << Changes::FieldArgumentDefaultChanged.new(type, field, old_arg, new_arg)
           end
 
-          if old_arg.type.graphql_definition != new_arg.type.graphql_definition
+          if old_arg.type.to_type_signature != new_arg.type.to_type_signature
             changes << Changes::FieldArgumentTypeChanged.new(type, field, old_arg, new_arg)
           end
 

--- a/lib/graphql/schema_comparator/diff/directive.rb
+++ b/lib/graphql/schema_comparator/diff/directive.rb
@@ -39,11 +39,11 @@ module GraphQL
         end
 
         def removed_arguments
-          old_arguments.values.select { |arg| !new_arguments[arg.name] }
+          old_arguments.values.select { |arg| !new_arguments[arg.graphql_name] }
         end
 
         def added_arguments
-          new_arguments.values.select { |arg| !old_arguments[arg.name] }
+          new_arguments.values.select { |arg| !old_arguments[arg.graphql_name] }
         end
 
         def each_common_argument(&block)

--- a/lib/graphql/schema_comparator/diff/directive_argument.rb
+++ b/lib/graphql/schema_comparator/diff/directive_argument.rb
@@ -19,7 +19,7 @@ module GraphQL
             changes << Changes::DirectiveArgumentDefaultChanged.new(directive, old_arg, new_arg)
           end
 
-          if old_arg.type.graphql_definition != new_arg.type.graphql_definition
+          if old_arg.type != new_arg.type
             changes << Changes::DirectiveArgumentTypeChanged.new(directive, old_arg, new_arg)
           end
 

--- a/lib/graphql/schema_comparator/diff/field.rb
+++ b/lib/graphql/schema_comparator/diff/field.rb
@@ -24,7 +24,7 @@ module GraphQL
             changes << Changes::FieldDeprecationChanged.new(new_type, old_field, new_field)
           end
 
-          if old_field.type.graphql_definition != new_field.type.graphql_definition
+          if old_field.type.to_type_signature != new_field.type.to_type_signature
             changes << Changes::FieldTypeChanged.new(new_type, old_field, new_field)
           end
 
@@ -51,12 +51,12 @@ module GraphQL
         )
 
         def arg_removals
-          removed = old_arguments.values.select { |arg| !new_arguments[arg.name] }
+          removed = old_arguments.values.select { |arg| !new_arguments[arg.graphql_name] }
           removed.map { |arg| Changes::FieldArgumentRemoved.new(new_type, old_field, arg) }
         end
 
         def arg_additions
-          removed = new_arguments.values.select { |arg| !old_arguments[arg.name] }
+          removed = new_arguments.values.select { |arg| !old_arguments[arg.graphql_name] }
           removed.map { |arg| Changes::FieldArgumentAdded.new(new_type, new_field, arg) }
         end
 

--- a/lib/graphql/schema_comparator/diff/input_field.rb
+++ b/lib/graphql/schema_comparator/diff/input_field.rb
@@ -21,7 +21,7 @@ module GraphQL
             changes << Changes::InputFieldDefaultChanged.new(old_type, old_field, new_field)
           end
 
-          if old_field.type.graphql_definition != new_field.type.graphql_definition
+          if old_field.type.to_type_signature != new_field.type.to_type_signature
             changes << Changes::InputFieldTypeChanged.new(old_type, old_field, new_field)
           end
 

--- a/lib/graphql/schema_comparator/diff/input_object.rb
+++ b/lib/graphql/schema_comparator/diff/input_object.rb
@@ -39,11 +39,11 @@ module GraphQL
         end
 
         def removed_fields
-          old_fields.values.select { |field| !new_fields[field.name] }
+          old_fields.values.select { |field| !new_fields[field.graphql_name] }
         end
 
         def added_fields
-          new_fields.values.select { |field| !old_fields[field.name] }
+          new_fields.values.select { |field| !old_fields[field.graphql_name] }
         end
       end
     end

--- a/lib/graphql/schema_comparator/diff/interface.rb
+++ b/lib/graphql/schema_comparator/diff/interface.rb
@@ -2,12 +2,12 @@ module GraphQL
   module SchemaComparator
     module Diff
       class Interface
-        def initialize(old_iface, new_iface)
-          @old_iface = old_iface
-          @new_iface = new_iface
+        def initialize(old_interface, new_interface)
+          @old_interface = old_interface
+          @new_interface = new_interface
 
-          @old_fields = old_iface.fields
-          @new_fields = new_iface.fields
+          @old_fields = old_interface.fields
+          @new_fields = new_interface.fields
         end
 
         def diff
@@ -16,7 +16,7 @@ module GraphQL
           changes += field_additions
 
           each_common_field do |old_field, new_field|
-            changes += Diff::Field.new(old_iface, new_iface, old_field, new_field).diff
+            changes += Diff::Field.new(old_interface, new_interface, old_field, new_field).diff
           end
 
           changes
@@ -24,23 +24,23 @@ module GraphQL
 
         private
 
-        attr_reader :old_iface, :new_iface, :old_fields, :new_fields
+        attr_reader :old_interface, :new_interface, :old_fields, :new_fields
 
         def field_removals
-          removed = old_fields.values.select { |field| !new_fields[field.name] }
-          removed.map { |field| Changes::FieldRemoved.new(old_iface, field) }
+          removed = old_fields.values.select { |field| !new_fields[field.graphql_name] }
+          removed.map { |field| Changes::FieldRemoved.new(old_interface, field) }
         end
 
         def field_additions
-          added = new_fields.values.select { |field| !old_fields[field.name] }
-          added.map { |field| Changes::FieldAdded.new(new_iface, field) }
+          added = new_fields.values.select { |field| !old_fields[field.graphql_name] }
+          added.map { |field| Changes::FieldAdded.new(new_interface, field) }
         end
 
         def each_common_field(&block)
           intersection = old_fields.keys & new_fields.keys
           intersection.each do |common_field|
-            old_field = old_iface.fields[common_field]
-            new_field = new_iface.fields[common_field]
+            old_field = old_interface.fields[common_field]
+            new_field = new_interface.fields[common_field]
 
             block.call(old_field, new_field)
           end

--- a/lib/graphql/schema_comparator/diff/object_type.rb
+++ b/lib/graphql/schema_comparator/diff/object_type.rb
@@ -3,8 +3,8 @@ module GraphQL
     module Diff
       class ObjectType
         def initialize(old_type, new_type)
-          @old_type = old_type.graphql_definition
-          @new_type = new_type.graphql_definition
+          @old_type = old_type
+          @new_type = new_type
 
           @old_fields = old_type.fields
           @new_fields = new_type.fields
@@ -41,25 +41,25 @@ module GraphQL
 
         def interface_removals
           removed = filter_interfaces(old_interfaces, new_interfaces)
-          removed.map { |iface| Changes::ObjectTypeInterfaceRemoved.new(iface, old_type) }
+          removed.map { |interface| Changes::ObjectTypeInterfaceRemoved.new(interface, old_type) }
         end
 
         def interface_additions
           added = filter_interfaces(new_interfaces, old_interfaces)
-          added.map { |iface| Changes::ObjectTypeInterfaceAdded.new(iface, new_type) }
+          added.map { |interface| Changes::ObjectTypeInterfaceAdded.new(interface, new_type) }
         end
 
         def filter_interfaces(interfaces, excluded_interfaces)
-          interfaces.select { |interface| !excluded_interfaces.map(&:graphql_definition).include?(interface.graphql_definition) }
+          interfaces.select { |interface| !excluded_interfaces.map(&:graphql_name).include?(interface.graphql_name) }
         end
 
         def field_removals
-          removed = old_fields.values.select { |field| !new_fields[field.name] }
+          removed = old_fields.values.select { |field| !new_fields[field.graphql_name] }
           removed.map { |field| Changes::FieldRemoved.new(old_type, field) }
         end
 
         def field_additions
-          added = new_fields.values.select { |field| !old_fields[field.name] }
+          added = new_fields.values.select { |field| !old_fields[field.graphql_name] }
           added.map { |field| Changes::FieldAdded.new(new_type, field) }
         end
 

--- a/lib/graphql/schema_comparator/diff/schema.rb
+++ b/lib/graphql/schema_comparator/diff/schema.rb
@@ -40,16 +40,16 @@ module GraphQL
           if old_type.kind != new_type.kind
             changes << Changes::TypeKindChanged.new(old_type, new_type)
           else
-            case old_type.graphql_definition
-            when GraphQL::EnumType
+            case old_type.kind.name
+            when "ENUM"
               changes += Diff::Enum.new(old_type, new_type).diff
-            when GraphQL::UnionType
+            when "UNION"
               changes += Diff::Union.new(old_type, new_type).diff
-            when GraphQL::InputObjectType
+            when "INPUT_OBJECT"
               changes += Diff::InputObject.new(old_type, new_type).diff
-            when GraphQL::ObjectType
+            when "OBJECT"
               changes += Diff::ObjectType.new(old_type, new_type).diff
-            when GraphQL::InterfaceType
+            when "INTERFACE"
               changes += Diff::Interface.new(old_type, new_type).diff
             end
           end
@@ -64,15 +64,15 @@ module GraphQL
         def changes_in_schema
           changes = []
 
-          if old_schema.query&.to_graphql != new_schema.query&.to_graphql
+          if old_schema.query&.graphql_name != new_schema.query&.graphql_name
             changes << Changes::SchemaQueryTypeChanged.new(old_schema, new_schema)
           end
 
-          if old_schema.mutation&.to_graphql != new_schema.mutation&.to_graphql
+          if old_schema.mutation&.graphql_name != new_schema.mutation&.graphql_name
             changes << Changes::SchemaMutationTypeChanged.new(old_schema, new_schema)
           end
 
-          if old_schema.subscription&.to_graphql != new_schema.subscription&.to_graphql
+          if old_schema.subscription&.graphql_name != new_schema.subscription&.graphql_name
             changes << Changes::SchemaSubscriptionTypeChanged.new(old_schema, new_schema)
           end
 

--- a/lib/graphql/schema_comparator/diff/union.rb
+++ b/lib/graphql/schema_comparator/diff/union.rb
@@ -34,7 +34,7 @@ module GraphQL
         end
 
         def filter_types(types, exclude_types)
-          types.select { |type| !exclude_types.map(&:graphql_definition).include?(type.graphql_definition) }
+          types.select { |type| !exclude_types.map(&:graphql_name).include?(type.graphql_name) }
         end
       end
     end

--- a/test/lib/graphql/schema_comparator/changes/field_argument_added_test.rb
+++ b/test/lib/graphql/schema_comparator/changes/field_argument_added_test.rb
@@ -1,37 +1,21 @@
 require "test_helper"
 
 class GraphQL::SchemaComparator::Changes::FieldArgumentAddedTest < Minitest::Test
-  def setup
-    @type = GraphQL::ObjectType.define do
-      name "Type"
-    end
+  class Type < GraphQL::Schema::Object
+    graphql_name "Type"
 
-    @field = GraphQL::Field.define do
-      name "field"
-    end
-
-    @nullable_argument = GraphQL::Argument.define do
-      name "foo"
-      type GraphQL::STRING_TYPE
-    end
-
-    @non_null_argument = GraphQL::Argument.define do
-      name "foo"
-      type !GraphQL::STRING_TYPE
-    end
-
-    @non_null_argument_with_default = GraphQL::Argument.define do
-      name "foo"
-      type !GraphQL::STRING_TYPE
-      default_value "bar"
+    field :field, String, null: true do
+      argument :nullable, String, required: false
+      argument :non_null, String, required: true
+      argument :non_null_with_default, String, required: true, default_value: "bar"
     end
   end
 
   def test_nullable_added
     change = GraphQL::SchemaComparator::Changes::FieldArgumentAdded.new(
-      @type,
-      @field,
-      @nullable_argument
+      Type,
+      Type.fields["field"],
+      Type.fields["field"].arguments["nullable"],
     )
 
     assert change.non_breaking?
@@ -39,9 +23,9 @@ class GraphQL::SchemaComparator::Changes::FieldArgumentAddedTest < Minitest::Tes
 
   def test_non_null_added
     change = GraphQL::SchemaComparator::Changes::FieldArgumentAdded.new(
-      @type,
-      @field,
-      @non_null_argument
+      Type,
+      Type.fields["field"],
+      Type.fields["field"].arguments["nonNull"],
     )
 
     assert change.breaking?
@@ -49,9 +33,9 @@ class GraphQL::SchemaComparator::Changes::FieldArgumentAddedTest < Minitest::Tes
 
   def test_non_null_with_default_added
     change = GraphQL::SchemaComparator::Changes::FieldArgumentAdded.new(
-      @type,
-      @field,
-      @non_null_argument_with_default
+      Type,
+      Type.fields["field"],
+      Type.fields["field"].arguments["nonNullWithDefault"],
     )
 
     assert change.non_breaking?

--- a/test/lib/graphql/schema_comparator/changes/field_argument_default_changed_test.rb
+++ b/test/lib/graphql/schema_comparator/changes/field_argument_default_changed_test.rb
@@ -1,33 +1,28 @@
 require "test_helper"
 
 class GraphQL::SchemaComparator::Changes::FieldArgumentDefaultChangedTest < Minitest::Test
-  def setup
-    @type = GraphQL::ObjectType.define do
-      name "Type"
+  class Type < GraphQL::Schema::Object
+    graphql_name "Type"
+
+    field :a, String, null: true do
+      argument :a, String, required: false
     end
 
-    @field_a = GraphQL::Field.define do
-      name "a"
-      argument :a, GraphQL::STRING_TYPE
+    field :b, String, null: true do
+      argument :a, String, required: false, default_value: "a"
     end
 
-    @field_b = GraphQL::Field.define do
-      name "a"
-      argument :a, GraphQL::STRING_TYPE, default_value: "a"
-    end
-
-    @field_c = GraphQL::Field.define do
-      name "a"
-      argument :a, GraphQL::STRING_TYPE, default_value: "b"
+    field :c, String, null: true do
+      argument :a, String, required: false, default_value: "b"
     end
   end
 
   def test_default_value_added
     change = GraphQL::SchemaComparator::Changes::FieldArgumentDefaultChanged.new(
-      @type,
-      @field_a,
-      @field_a.arguments["a"],
-      @field_b.arguments["a"],
+      Type,
+      Type.fields["a"],
+      Type.fields["a"].arguments["a"],
+      Type.fields["b"].arguments["a"],
     )
 
     expected = "Default value `a` was added to argument `a` on field `Type.a`"
@@ -36,10 +31,10 @@ class GraphQL::SchemaComparator::Changes::FieldArgumentDefaultChangedTest < Mini
 
   def test_default_value_changed
     change = GraphQL::SchemaComparator::Changes::FieldArgumentDefaultChanged.new(
-      @type,
-      @field_a,
-      @field_b.arguments["a"],
-      @field_c.arguments["a"],
+      Type,
+      Type.fields["a"],
+      Type.fields["b"].arguments["a"],
+      Type.fields["c"].arguments["a"],
     )
 
     expected = "Default value for argument `a` on field `Type.a` changed from `a` to `b`"

--- a/test/lib/graphql/schema_comparator/changes/input_field_added_test.rb
+++ b/test/lib/graphql/schema_comparator/changes/input_field_added_test.rb
@@ -1,32 +1,18 @@
 require "test_helper"
 
 class GraphQL::SchemaComparator::Changes::InputFieldAddedTest < Minitest::Test
-  def setup
-    @input_type = GraphQL::InputObjectType.define do
-      name "Input"
-    end
+  class Type < GraphQL::Schema::InputObject
+    graphql_name "Input"
 
-    @nullable_input_field = GraphQL::Argument.define do
-      name "foo"
-      type GraphQL::STRING_TYPE
-    end
-
-    @non_null_input_field = GraphQL::Argument.define do
-      name "foo"
-      type !GraphQL::STRING_TYPE
-    end
-
-    @non_null_input_field_with_default = GraphQL::Argument.define do
-      name "foo"
-      type !GraphQL::STRING_TYPE
-      default_value "bar"
-    end
+    argument :nullable, String, required: false
+    argument :non_null, String, required: true
+    argument :non_null_with_default, String, required: true, default_value: "bar"
   end
 
   def test_nullable_added
     change = GraphQL::SchemaComparator::Changes::InputFieldAdded.new(
-      @input_type,
-      @nullable_input_field
+      Type,
+      Type.arguments["nullable"],
     )
 
     assert change.non_breaking?
@@ -34,8 +20,8 @@ class GraphQL::SchemaComparator::Changes::InputFieldAddedTest < Minitest::Test
 
   def test_non_null_added
     change = GraphQL::SchemaComparator::Changes::InputFieldAdded.new(
-      @input_type,
-      @non_null_input_field
+      Type,
+      Type.arguments["nonNull"],
     )
 
     assert change.breaking?
@@ -43,8 +29,8 @@ class GraphQL::SchemaComparator::Changes::InputFieldAddedTest < Minitest::Test
 
   def test_non_null_with_default_added
     change = GraphQL::SchemaComparator::Changes::InputFieldAdded.new(
-      @input_type,
-      @non_null_input_field_with_default
+      Type,
+      Type.arguments["nonNullWithDefault"],
     )
 
     assert change.non_breaking?

--- a/test/lib/graphql/schema_comparator/diff/directive_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/directive_test.rb
@@ -1,25 +1,23 @@
 require "test_helper"
 
 class GraphQL::SchemaComparator::Diff::DirectiveTest < Minitest::Test
-  def setup
-    @old_directive = GraphQL::Directive.define do
-      name "Default"
-      argument :a, types.Int, default_value: "No", description: "A Description"
-      argument :b, types.String
-      locations [:QUERY, :MUTATION]
-    end
-
-    @new_directive = GraphQL::Directive.define do
-      name "Default"
-      argument :a, types.String, default_value: "Yes", description: "Another Description"
-      argument :c, types.String
-      locations [:MUTATION, :SUBSCRIPTION]
-    end
-
-     @differ = GraphQL::SchemaComparator::Diff::Directive.new(@old_directive, @new_directive)
-  end
-
   def test_diff
+    old_directive = Class.new(GraphQL::Schema::Directive) do
+      graphql_name "Default"
+      argument :a, Integer, required: true, default_value: "No", description: "A Description"
+      argument :b, String, required: true
+      locations :QUERY, :MUTATION
+    end
+
+    new_directive = Class.new(GraphQL::Schema::Directive) do
+      graphql_name "Default"
+      argument :a, String, required: true, default_value: "Yes", description: "Another Description"
+      argument :c, String, required: true
+      locations :MUTATION, :SUBSCRIPTION
+    end
+
+    differ = GraphQL::SchemaComparator::Diff::Directive.new(old_directive, new_directive)
+
     assert_equal [
       "Location `QUERY` was removed from directive `Default`",
       "Location `SUBSCRIPTION` was added to directive `Default`",
@@ -27,7 +25,7 @@ class GraphQL::SchemaComparator::Diff::DirectiveTest < Minitest::Test
       "Argument `b` was removed from directive `Default`",
       "Description for argument `a` on directive `Default` changed from `A Description` to `Another Description`",
       "Default value for argument `a` on directive `Default` changed from `No` to `Yes`",
-      "Type for argument `a` on directive `Default` changed from `Int` to `String`"
-    ], @differ.diff.map(&:message)
+      "Type for argument `a` on directive `Default` changed from `Int!` to `String!`"
+    ], differ.diff.map(&:message)
   end
 end

--- a/test/lib/graphql/schema_comparator/diff/enum_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/enum_test.rb
@@ -1,33 +1,31 @@
 require "test_helper"
 
 class GraphQL::SchemaComparator::Diff::EnumTest < Minitest::Test
-  def setup
-    @old_enum = GraphQL::EnumType.define do
-     name "Languages"
-     description "Programming languages for Web projects"
-     value("PYTHON", "A dynamic, function-oriented language", deprecation_reason: "a")
-     value("RUBY", "A very dynamic language aimed at programmer happiness")
-     value("JAVASCRIPT", "Accidental lingua franca of the web")
-    end
-
-    @new_enum = GraphQL::EnumType.define do
-     name "Languages"
-     description "Programming languages for all projects"
-     value("PYTHON", "A dynamic, function-oriented language", deprecation_reason: "b")
-     value("JAVASCRIPT", "Accidental lingua franca of the web lol", deprecation_reason: "Because!")
-     value("CPLUSPLUS", "iamverysmart")
-    end
-
-    @differ = GraphQL::SchemaComparator::Diff::Enum.new(@old_enum, @new_enum)
-  end
-
   def test_diff
+    old_enum = Class.new(GraphQL::Schema::Enum) do
+      graphql_name "Languages"
+      description "Programming languages for Web projects"
+      value("PYTHON", "A dynamic, function-oriented language", deprecation_reason: "a")
+      value("RUBY", "A very dynamic language aimed at programmer happiness")
+      value("JAVASCRIPT", "Accidental lingua franca of the web")
+    end
+
+    new_enum = Class.new(GraphQL::Schema::Enum) do
+      graphql_name "Languages"
+      description "Programming languages for all projects"
+      value("PYTHON", "A dynamic, function-oriented language", deprecation_reason: "b")
+      value("JAVASCRIPT", "Accidental lingua franca of the web lol", deprecation_reason: "Because!")
+      value("CPLUSPLUS", "iamverysmart")
+    end
+
+    differ = GraphQL::SchemaComparator::Diff::Enum.new(old_enum, new_enum)
+
     assert_equal [
-     "Enum value `RUBY` was removed from enum `Languages`",
-     "Enum value `CPLUSPLUS` was added to enum `Languages`",
-     "Enum value `Languages.PYTHON` deprecation reason changed from `a` to `b`",
-     "Description for enum value `Languages.JAVASCRIPT` changed from `Accidental lingua franca of the web` to `Accidental lingua franca of the web lol`",
-     "Enum value `Languages.JAVASCRIPT` was deprecated with reason `Because!`",
-    ], @differ.diff.map(&:message)
+      "Enum value `RUBY` was removed from enum `Languages`",
+      "Enum value `CPLUSPLUS` was added to enum `Languages`",
+      "Enum value `Languages.PYTHON` deprecation reason changed from `a` to `b`",
+      "Description for enum value `Languages.JAVASCRIPT` changed from `Accidental lingua franca of the web` to `Accidental lingua franca of the web lol`",
+      "Enum value `Languages.JAVASCRIPT` was deprecated with reason `Because!`",
+    ], differ.diff.map(&:message)
   end
 end

--- a/test/lib/graphql/schema_comparator/diff/field_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/field_test.rb
@@ -1,39 +1,29 @@
 require "test_helper"
 
 class GraphQL::SchemaComparator::Diff::FieldTest < Minitest::Test
-  def setup
-    @type = GraphQL::ObjectType.define do
-      name "Foo"
-    end
+  class Type < GraphQL::Schema::Object
+    graphql_name "Foo"
   end
 
   def test_field_type_change
-    old_field = GraphQL::Field.define do
-      name "foo"
-      type types.String
-    end
+    old_field = Type.field(:bar, "String", null: true)
+    new_field = Type.field(:bar, "Boolean", null: true)
 
-    new_field = old_field.redefine { type types.Boolean }
-
-    differ = GraphQL::SchemaComparator::Diff::Field.new(@type, @type, old_field, new_field)
+    differ = GraphQL::SchemaComparator::Diff::Field.new(Type, Type, old_field, new_field)
     changes = differ.diff
     change = differ.diff.first
 
     assert_equal 1, changes.size
     assert change.breaking?
 
-    assert_equal "Field `Foo.foo` changed type from `String` to `Boolean`", change.message
+    assert_equal "Field `Foo.bar` changed type from `String` to `Boolean`", change.message
   end
 
   def test_field_type_change_from_scalar_to_list_of_the_same_type
-    old_field = GraphQL::Field.define do
-      name "bar"
-      type types[types.String]
-    end
+    old_field = Type.field(:bar, ["String", null: true], null: true)
+    new_field = Type.field(:bar, "String", null: true)
 
-    new_field = old_field.redefine { type types.String }
-
-    differ = GraphQL::SchemaComparator::Diff::Field.new(@type, @type, old_field, new_field)
+    differ = GraphQL::SchemaComparator::Diff::Field.new(Type, Type, old_field, new_field)
     changes = differ.diff
     change = differ.diff.first
 
@@ -44,14 +34,10 @@ class GraphQL::SchemaComparator::Diff::FieldTest < Minitest::Test
   end
 
   def test_field_type_change_from_non_null_to_null_of_the_same_type
-    old_field = GraphQL::Field.define do
-      name "bar"
-      type !types.String
-    end
+    old_field = Type.field(:bar, "String", null: false)
+    new_field = Type.field(:bar, "String", null: true)
 
-    new_field = old_field.redefine { type types.String }
-
-    differ = GraphQL::SchemaComparator::Diff::Field.new(@type, @type, old_field, new_field)
+    differ = GraphQL::SchemaComparator::Diff::Field.new(Type, Type, old_field, new_field)
     changes = differ.diff
     change = differ.diff.first
 
@@ -62,14 +48,10 @@ class GraphQL::SchemaComparator::Diff::FieldTest < Minitest::Test
   end
 
   def test_field_type_change_from_null_to_non_null_of_the_same_type
-    old_field = GraphQL::Field.define do
-      name "bar"
-      type types.String
-    end
+    old_field = Type.field(:bar, "String", null: true)
+    new_field = Type.field(:bar, "String", null: false)
 
-    new_field = old_field.redefine { type !types.String }
-
-    differ = GraphQL::SchemaComparator::Diff::Field.new(@type, @type, old_field, new_field)
+    differ = GraphQL::SchemaComparator::Diff::Field.new(Type, Type, old_field, new_field)
     changes = differ.diff
     change = differ.diff.first
 
@@ -80,14 +62,10 @@ class GraphQL::SchemaComparator::Diff::FieldTest < Minitest::Test
   end
 
   def test_field_type_change_nullability_change_on_lists_of_same_type
-    old_field = GraphQL::Field.define do
-      name "bar"
-      type !types[types.String]
-    end
+    old_field = Type.field(:bar, ["String", null: true], null: false)
+    new_field = Type.field(:bar, ["String", null: true], null: true)
 
-    new_field = old_field.redefine { type types[types.String] }
-
-    differ = GraphQL::SchemaComparator::Diff::Field.new(@type, @type, old_field, new_field)
+    differ = GraphQL::SchemaComparator::Diff::Field.new(Type, Type, old_field, new_field)
     changes = differ.diff
     change = differ.diff.first
 
@@ -98,14 +76,10 @@ class GraphQL::SchemaComparator::Diff::FieldTest < Minitest::Test
   end
 
   def test_field_type_change_within_lists_of_the_same_underlying_types
-    old_field = GraphQL::Field.define do
-      name "bar"
-      type !types[!types.String]
-    end
+    old_field = Type.field(:bar, ["String"], null: false)
+    new_field = Type.field(:bar, ["String", null: true], null: false)
 
-    new_field = old_field.redefine { type !types[types.String] }
-
-    differ = GraphQL::SchemaComparator::Diff::Field.new(@type, @type, old_field, new_field)
+    differ = GraphQL::SchemaComparator::Diff::Field.new(Type, Type, old_field, new_field)
     changes = differ.diff
     change = differ.diff.first
 
@@ -116,14 +90,10 @@ class GraphQL::SchemaComparator::Diff::FieldTest < Minitest::Test
   end
 
   def test_field_type_change_within_and_on_list_of_same_type
-    old_field = GraphQL::Field.define do
-      name "bar"
-      type !types[!types.String]
-    end
+    old_field = Type.field(:bar, ["String"], null: false)
+    new_field = Type.field(:bar, ["String", null: true], null: true)
 
-    new_field = old_field.redefine { type types[types.String] }
-
-    differ = GraphQL::SchemaComparator::Diff::Field.new(@type, @type, old_field, new_field)
+    differ = GraphQL::SchemaComparator::Diff::Field.new(Type, Type, old_field, new_field)
     changes = differ.diff
     change = differ.diff.first
 
@@ -134,14 +104,10 @@ class GraphQL::SchemaComparator::Diff::FieldTest < Minitest::Test
   end
 
   def test_field_type_change_within_and_on_list_of_same_type_of_different_types
-    old_field = GraphQL::Field.define do
-      name "bar"
-      type !types[!types.String]
-    end
+    old_field = Type.field(:bar, ["String"], null: false)
+    new_field = Type.field(:bar, ["Boolean", null: true], null: true)
 
-    new_field = old_field.redefine { type types[types.Boolean] }
-
-    differ = GraphQL::SchemaComparator::Diff::Field.new(@type, @type, old_field, new_field)
+    differ = GraphQL::SchemaComparator::Diff::Field.new(Type, Type, old_field, new_field)
     changes = differ.diff
     change = differ.diff.first
 

--- a/test/lib/graphql/schema_comparator/diff/input_field_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/input_field_test.rb
@@ -1,39 +1,29 @@
 require "test_helper"
 
 class GraphQL::SchemaComparator::Diff::InputFieldTest < Minitest::Test
-  def setup
-    @type = GraphQL::InputObjectType.define do
-      name "Input"
-    end
+  class Input < GraphQL::Schema::InputObject
+    graphql_name "Input"
   end
 
   def test_diff_input_field_type_change
-    old_input_field = GraphQL::Argument.define do
-      name "foo"
-      type types.String
-    end
+    old_input_field = GraphQL::Schema::Argument.new(:arg, "String", required: false, owner: Input)
+    new_input_field = GraphQL::Schema::Argument.new(:arg, "Boolean", required: false, owner: Input)
 
-    new_input_field = old_input_field.redefine { type types.Boolean }
-
-    differ = GraphQL::SchemaComparator::Diff::InputField.new(@type, @type, old_input_field, new_input_field)
+    differ = GraphQL::SchemaComparator::Diff::InputField.new(Input, Input, old_input_field, new_input_field)
     changes = differ.diff
     change = differ.diff.first
 
     assert_equal 1, changes.size
     assert change.breaking?
 
-    assert_equal "Input field `Input.foo` changed type from `String` to `Boolean`", change.message
+    assert_equal "Input field `Input.arg` changed type from `String` to `Boolean`", change.message
   end
 
   def test_diff_input_field_type_change_from_scalar_to_list_of_the_same_type
-    old_input_field = GraphQL::Argument.define do
-      name "arg"
-      type types[types.String]
-    end
+    old_input_field = GraphQL::Schema::Argument.new(:arg, ["String", null: true], required: false, owner: Input)
+    new_input_field = GraphQL::Schema::Argument.new(:arg, "String", required: false, owner: Input)
 
-    new_input_field = old_input_field.redefine { type types.String }
-
-    differ = GraphQL::SchemaComparator::Diff::InputField.new(@type, @type, old_input_field, new_input_field)
+    differ = GraphQL::SchemaComparator::Diff::InputField.new(Input, Input, old_input_field, new_input_field)
     changes = differ.diff
     change = differ.diff.first
 
@@ -44,14 +34,10 @@ class GraphQL::SchemaComparator::Diff::InputFieldTest < Minitest::Test
   end
 
   def test_diff_input_field_type_change_from_non_null_to_null_same_type
-    old_input_field = GraphQL::Argument.define do
-      name "arg"
-      type !types.String
-    end
+    old_input_field = GraphQL::Schema::Argument.new(:arg, "String", required: true, owner: Input)
+    new_input_field = GraphQL::Schema::Argument.new(:arg, "String", required: false, owner: Input)
 
-    new_input_field = old_input_field.redefine { type types.String }
-
-    differ = GraphQL::SchemaComparator::Diff::InputField.new(@type, @type, old_input_field, new_input_field)
+    differ = GraphQL::SchemaComparator::Diff::InputField.new(Input, Input, old_input_field, new_input_field)
     changes = differ.diff
     change = differ.diff.first
 
@@ -62,14 +48,10 @@ class GraphQL::SchemaComparator::Diff::InputFieldTest < Minitest::Test
   end
 
   def test_diff_input_field_type_change_from_null_to_non_null_of_same_type
-    old_input_field = GraphQL::Argument.define do
-      name "arg"
-      type types.String
-    end
+    old_input_field = GraphQL::Schema::Argument.new(:arg, "String", required: false, owner: Input)
+    new_input_field = GraphQL::Schema::Argument.new(:arg, "String", required: true, owner: Input)
 
-    new_input_field = old_input_field.redefine { type !types.String }
-
-    differ = GraphQL::SchemaComparator::Diff::InputField.new(@type, @type, old_input_field, new_input_field)
+    differ = GraphQL::SchemaComparator::Diff::InputField.new(Input, Input, old_input_field, new_input_field)
     changes = differ.diff
     change = differ.diff.first
 
@@ -80,14 +62,10 @@ class GraphQL::SchemaComparator::Diff::InputFieldTest < Minitest::Test
   end
 
   def test_diff_input_field_type_nullability_change_on_lists_of_the_same_underlying_types
-    old_input_field = GraphQL::Argument.define do
-      name "arg"
-      type !types[types.String]
-    end
+    old_input_field = GraphQL::Schema::Argument.new(:arg, ["String", null: true], required: true, owner: Input)
+    new_input_field = GraphQL::Schema::Argument.new(:arg, ["String", null: true], required: false, owner: Input)
 
-    new_input_field = old_input_field.redefine { type types[types.String] }
-
-    differ = GraphQL::SchemaComparator::Diff::InputField.new(@type, @type, old_input_field, new_input_field)
+    differ = GraphQL::SchemaComparator::Diff::InputField.new(Input, Input, old_input_field, new_input_field)
     changes = differ.diff
     change = differ.diff.first
 
@@ -98,14 +76,10 @@ class GraphQL::SchemaComparator::Diff::InputFieldTest < Minitest::Test
   end
 
   def test_diff_input_field_type_change_within_lists_of_the_same_underlying_types
-    old_input_field = GraphQL::Argument.define do
-      name "arg"
-      type !types[!types.String]
-    end
+    old_input_field = GraphQL::Schema::Argument.new(:arg, ["String"], required: true, owner: Input)
+    new_input_field = GraphQL::Schema::Argument.new(:arg, ["String", null: true], required: true, owner: Input)
 
-    new_input_field = old_input_field.redefine { type !types[types.String] }
-
-    differ = GraphQL::SchemaComparator::Diff::InputField.new(@type, @type, old_input_field, new_input_field)
+    differ = GraphQL::SchemaComparator::Diff::InputField.new(Input, Input, old_input_field, new_input_field)
     changes = differ.diff
     change = differ.diff.first
 
@@ -116,14 +90,10 @@ class GraphQL::SchemaComparator::Diff::InputFieldTest < Minitest::Test
   end
 
   def test_input_field_type_changes_on_and_within_lists_of_the_same_underlying_types
-    old_input_field = GraphQL::Argument.define do
-      name "arg"
-      type !types[!types.String]
-    end
+    old_input_field = GraphQL::Schema::Argument.new(:arg, ["String"], required: true, owner: Input)
+    new_input_field = GraphQL::Schema::Argument.new(:arg, ["String", null: true], required: false, owner: Input)
 
-    new_input_field = old_input_field.redefine { type types[types.String] }
-
-    differ = GraphQL::SchemaComparator::Diff::InputField.new(@type, @type, old_input_field, new_input_field)
+    differ = GraphQL::SchemaComparator::Diff::InputField.new(Input, Input, old_input_field, new_input_field)
     changes = differ.diff
     change = differ.diff.first
 
@@ -134,14 +104,10 @@ class GraphQL::SchemaComparator::Diff::InputFieldTest < Minitest::Test
   end
 
   def test_input_field_type_changes_on_and_within_lists_of_different_underlying_types
-    old_input_field = GraphQL::Argument.define do
-      name "arg"
-      type !types[!types.String]
-    end
+    old_input_field = GraphQL::Schema::Argument.new(:arg, ["String"], required: true, owner: Input)
+    new_input_field = GraphQL::Schema::Argument.new(:arg, ["Boolean", null: true], required: false, owner: Input)
 
-    new_input_field = old_input_field.redefine { type types[types.Boolean] }
-
-    differ = GraphQL::SchemaComparator::Diff::InputField.new(@type, @type, old_input_field, new_input_field)
+    differ = GraphQL::SchemaComparator::Diff::InputField.new(Input, Input, old_input_field, new_input_field)
     changes = differ.diff
     change = differ.diff.first
 

--- a/test/lib/graphql/schema_comparator/result_test.rb
+++ b/test/lib/graphql/schema_comparator/result_test.rb
@@ -1,18 +1,30 @@
 require "test_helper"
 
 class GraphQL::SchemaComparator::ResultTest < Minitest::Test
+  class Type < GraphQL::Schema::Object
+    field :foo, String, null: true
+  end
+
+  class EnumType < GraphQL::Schema::Enum
+    value :foo
+  end
+
   def test_changes
-    removed_z = GraphQL::SchemaComparator::Changes::FieldRemoved.new(GraphQL::ObjectType.define(name: "Z"), GraphQL::Field.define(name: "a"))
-    removed_a = GraphQL::SchemaComparator::Changes::FieldRemoved.new(GraphQL::ObjectType.define(name: "A"), GraphQL::Field.define(name: "a"))
-    added_a = GraphQL::SchemaComparator::Changes::FieldAdded.new(GraphQL::ObjectType.define(name: "A"), GraphQL::Field.define(name: "a"))
+
+    removed_z = GraphQL::SchemaComparator::Changes::FieldRemoved.new(Type, Type.fields["foo"])
+    removed_a = GraphQL::SchemaComparator::Changes::FieldRemoved.new(Type, Type.fields["foo"])
+    added_a = GraphQL::SchemaComparator::Changes::FieldAdded.new(Type, Type.fields["foo"])
+
     result = GraphQL::SchemaComparator::Result.new([removed_z, added_a, removed_a])
+
     assert_equal [removed_a, removed_z, added_a], result.changes
   end
 
   def test_identical_returns_false_when_schemas_have_changes
     result = GraphQL::SchemaComparator::Result.new([
-      GraphQL::SchemaComparator::Changes::FieldRemoved.new(GraphQL::ObjectType.new, GraphQL::Field.new)
+      GraphQL::SchemaComparator::Changes::FieldRemoved.new(Type, Type.fields["foo"])
     ])
+
     assert_equal false, result.identical?
   end
 
@@ -23,23 +35,25 @@ class GraphQL::SchemaComparator::ResultTest < Minitest::Test
 
   def test_breaking_returns_true_when_at_least_one_breaking_change
     result = GraphQL::SchemaComparator::Result.new([
-      GraphQL::SchemaComparator::Changes::FieldRemoved.new(GraphQL::ObjectType.new, GraphQL::Field.new)
+      GraphQL::SchemaComparator::Changes::FieldRemoved.new(Type, Type.fields["foo"])
     ])
+
     assert_equal true, result.breaking?
   end
 
   def test_breaking_returns_false_when_no_breaking_changes
     result = GraphQL::SchemaComparator::Result.new([
-      GraphQL::SchemaComparator::Changes::FieldAdded.new(GraphQL::ObjectType.new, GraphQL::Field.new)
+      GraphQL::SchemaComparator::Changes::FieldAdded.new(Type, Type.fields["foo"])
     ])
+
     assert_equal false, result.breaking?
   end
 
   def test_breaking_changes
-    enum_value_added = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(GraphQL::EnumType.new, GraphQL::EnumType::EnumValue.new)
-    field_added = GraphQL::SchemaComparator::Changes::FieldAdded.new(GraphQL::ObjectType.new, GraphQL::Field.new)
-    field_removed = GraphQL::SchemaComparator::Changes::FieldRemoved.new(GraphQL::ObjectType.new, GraphQL::Field.new)
-    type_description_changed = GraphQL::SchemaComparator::Changes::TypeDescriptionChanged.new(GraphQL::ObjectType.new, GraphQL::ObjectType.new)
+    enum_value_added = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(EnumType, EnumType.values["foo"])
+    field_added = GraphQL::SchemaComparator::Changes::FieldAdded.new(Type, Type.fields["foo"])
+    field_removed = GraphQL::SchemaComparator::Changes::FieldRemoved.new(Type, Type.fields["foo"])
+    type_description_changed = GraphQL::SchemaComparator::Changes::TypeDescriptionChanged.new(Type, Type)
 
     result = GraphQL::SchemaComparator::Result.new([
       enum_value_added,
@@ -52,10 +66,10 @@ class GraphQL::SchemaComparator::ResultTest < Minitest::Test
   end
 
   def test_dangerous_changes
-    enum_value_added = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(GraphQL::EnumType.new, GraphQL::EnumType::EnumValue.new)
-    field_added = GraphQL::SchemaComparator::Changes::FieldAdded.new(GraphQL::ObjectType.new, GraphQL::Field.new)
-    field_removed = GraphQL::SchemaComparator::Changes::FieldRemoved.new(GraphQL::ObjectType.new, GraphQL::Field.new)
-    type_description_changed = GraphQL::SchemaComparator::Changes::TypeDescriptionChanged.new(GraphQL::ObjectType.new, GraphQL::ObjectType.new)
+    enum_value_added = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(EnumType, EnumType.values["foo"])
+    field_added = GraphQL::SchemaComparator::Changes::FieldAdded.new(Type, Type.fields["foo"])
+    field_removed = GraphQL::SchemaComparator::Changes::FieldRemoved.new(Type, Type.fields["foo"])
+    type_description_changed = GraphQL::SchemaComparator::Changes::TypeDescriptionChanged.new(Type, Type)
 
     result = GraphQL::SchemaComparator::Result.new([
       enum_value_added,
@@ -68,10 +82,10 @@ class GraphQL::SchemaComparator::ResultTest < Minitest::Test
   end
 
   def test_non_breaking_changes
-    field_added = GraphQL::SchemaComparator::Changes::FieldAdded.new(GraphQL::ObjectType.new, GraphQL::Field.new)
-    enum_value_added = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(GraphQL::EnumType.new, GraphQL::EnumType::EnumValue.new)
-    field_removed = GraphQL::SchemaComparator::Changes::FieldRemoved.new(GraphQL::ObjectType.new, GraphQL::Field.new)
-    type_description_changed = GraphQL::SchemaComparator::Changes::TypeDescriptionChanged.new(GraphQL::ObjectType.new, GraphQL::ObjectType.new)
+    enum_value_added = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(EnumType, EnumType.values["foo"])
+    field_added = GraphQL::SchemaComparator::Changes::FieldAdded.new(Type, Type.fields["foo"])
+    field_removed = GraphQL::SchemaComparator::Changes::FieldRemoved.new(Type, Type.fields["foo"])
+    type_description_changed = GraphQL::SchemaComparator::Changes::TypeDescriptionChanged.new(Type, Type)
 
     result = GraphQL::SchemaComparator::Result.new([
       enum_value_added,


### PR DESCRIPTION
Fixes #45

Removes all legacy/deprecated usage of `to_graphql` and `graphql_definition` which would result in legacy types being defined.

Also adds new tests for multiple versions of the `graphql` gem. This should work from 1.10 to the latest (1.13).