### PR TITLE
directive breaking change false-positive

### DIFF
--- a/lib/graphql/schema_comparator/diff/directive_argument.rb
+++ b/lib/graphql/schema_comparator/diff/directive_argument.rb
@@ -19,7 +19,7 @@ module GraphQL
             changes << Changes::DirectiveArgumentDefaultChanged.new(directive, old_arg, new_arg)
           end
 
-          if old_arg.type != new_arg.type
+          if old_arg.type.to_type_signature != new_arg.type.to_type_signature
             changes << Changes::DirectiveArgumentTypeChanged.new(directive, old_arg, new_arg)
           end
 

--- a/test/lib/graphql/schema_comparator/changes/directives_unchanged_test.rb
+++ b/test/lib/graphql/schema_comparator/changes/directives_unchanged_test.rb
@@ -24,5 +24,6 @@ class GraphQL::SchemaComparator::Changes::DirectivesUnchangedTest < Minitest::Te
     result = GraphQL::SchemaComparator.compare(schema_idl, schema_idl)
 
     assert_equal [], result.breaking_changes.map(&:message)
+    assert_equal [], result.non_breaking_changes.map(&:message)
   end
 end

--- a/test/lib/graphql/schema_comparator/changes/directives_unchanged_test.rb
+++ b/test/lib/graphql/schema_comparator/changes/directives_unchanged_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class GraphQL::SchemaComparator::Changes::DirectivesUnchangedTest < Minitest::Test
+  def test_identical_schemas
+    schema_idl = <<~SCHEMA
+      schema {
+        query: QueryRoot
+      }
+      
+      type QueryRoot {
+        name(locale: String = "en"): String!
+      }
+      
+      directive @colorFormat(
+        colorFormat: ColorFormatEnum!
+      ) on QUERY
+      
+      enum ColorFormatEnum {
+        HSL
+        LCH
+      }
+    SCHEMA
+
+    result = GraphQL::SchemaComparator.compare(schema_idl, schema_idl)
+
+    assert_equal [], result.breaking_changes.map(&:message)
+  end
+end


### PR DESCRIPTION
When checking directive arguments for equivalence, check the type signature strings instead of the type graph objects.

Fixes #48.
