### PR TITLE
Fix safe type change comparison

### DIFF
--- a/lib/graphql/schema_comparator/changes/safe_type_change.rb
+++ b/lib/graphql/schema_comparator/changes/safe_type_change.rb
@@ -4,7 +4,7 @@ module GraphQL
       module SafeTypeChange
         def safe_change_for_field?(old_type, new_type)
           if !old_type.kind.wraps? && !new_type.kind.wraps?
-            old_type == new_type
+            old_type.graphql_name == new_type.graphql_name
           elsif new_type.kind.non_null?
             of_type = old_type.kind.non_null? ? old_type.of_type : old_type
             safe_change_for_field?(of_type, new_type.of_type)
@@ -18,7 +18,7 @@ module GraphQL
 
         def safe_change_for_input_value?(old_type, new_type)
           if !old_type.kind.wraps? && !new_type.kind.wraps?
-            old_type == new_type
+            old_type.graphql_name == new_type.graphql_name
           elsif old_type.kind.list? && new_type.kind.list?
             safe_change_for_input_value?(old_type.of_type, new_type.of_type)
           elsif old_type.kind.non_null?


### PR DESCRIPTION
Fixes #52

Comparison can't be done with equality of classes since non-scalar types will always generate different classes when schemas are parsed.

The comparison should be done by the type's name in this case.