### PR TITLE
More selective detection of breaking/dangerous enum value changes

### DIFF
--- a/lib/graphql/schema_comparator.rb
+++ b/lib/graphql/schema_comparator.rb
@@ -4,6 +4,7 @@ require "graphql/schema_comparator/version"
 require "graphql/schema_comparator/result"
 
 require 'graphql/schema_comparator/changes'
+require 'graphql/schema_comparator/enum_usage'
 
 require "graphql/schema_comparator/diff/schema"
 require "graphql/schema_comparator/diff/argument"

--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -102,9 +102,15 @@ module GraphQL
         def initialize(enum_type, enum_value, usage)
           @enum_value = enum_value
           @enum_type = enum_type
-          @criticality = usage.input? ? Changes::Criticality.breaking(
-            reason: "Removing an enum value will cause existing queries that use this enum value to error."
-          ) : Changes::Criticality.non_breaking
+          @criticality = if usage.input?
+                           Changes::Criticality.breaking(
+                             reason: "Removing an enum value will cause existing queries that use this enum value to error."
+                           )
+                         else
+                           Changes::Criticality.non_breaking(
+                             reason: "Removing an enum value for enums used only in outputs is non-breaking."
+                           )
+                         end
         end
 
         def message
@@ -516,10 +522,16 @@ module GraphQL
         def initialize(enum_type, enum_value, usage)
           @enum_type = enum_type
           @enum_value = enum_value
-          @criticality = usage.output? ? Changes::Criticality.dangerous(
-            reason: "Adding an enum value may break existing clients that were not " \
-              "programming defensively against an added case when querying an enum."
-          ) : Changes::Criticality.non_breaking
+          @criticality = if usage.output?
+                           Changes::Criticality.dangerous(
+                             reason: "Adding an enum value may break existing clients that were not " \
+                              "programmed defensively against an added case when querying an enum."
+                           )
+                         else
+                           Changes::Criticality.non_breaking(
+                             reason: "Adding an enum value for enums used only in inputs is non-breaking."
+                           )
+                         end
         end
 
         def message

--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -99,12 +99,12 @@ module GraphQL
       class EnumValueRemoved < AbstractChange
         attr_reader :enum_value, :enum_type, :criticality
 
-        def initialize(enum_type, enum_value)
+        def initialize(enum_type, enum_value, usage)
           @enum_value = enum_value
           @enum_type = enum_type
-          @criticality = Changes::Criticality.breaking(
+          @criticality = usage.input? ? Changes::Criticality.breaking(
             reason: "Removing an enum value will cause existing queries that use this enum value to error."
-          )
+          ) : Changes::Criticality.non_breaking
         end
 
         def message
@@ -513,13 +513,13 @@ module GraphQL
       class EnumValueAdded < AbstractChange
         attr_reader :enum_type, :enum_value, :criticality
 
-        def initialize(enum_type, enum_value)
+        def initialize(enum_type, enum_value, usage)
           @enum_type = enum_type
           @enum_value = enum_value
-          @criticality = Changes::Criticality.dangerous(
+          @criticality = usage.output? ? Changes::Criticality.dangerous(
             reason: "Adding an enum value may break existing clients that were not " \
               "programming defensively against an added case when querying an enum."
-          )
+          ) : Changes::Criticality.non_breaking
         end
 
         def message

--- a/lib/graphql/schema_comparator/diff/enum.rb
+++ b/lib/graphql/schema_comparator/diff/enum.rb
@@ -2,19 +2,21 @@ module GraphQL
   module SchemaComparator
     module Diff
       class Enum
-        def initialize(old_enum, new_enum)
+        def initialize(old_enum, new_enum, usage)
           @old_enum = old_enum
           @new_enum = new_enum
 
           @old_values = old_enum.values
           @new_values = new_enum.values
+
+          @usage = usage
         end
 
         def diff
           changes = []
 
-          changes += removed_values.map { |value| Changes::EnumValueRemoved.new(old_enum, value) }
-          changes += added_values.map { |value| Changes::EnumValueAdded.new(new_enum, value) }
+          changes += removed_values.map { |value| Changes::EnumValueRemoved.new(old_enum, value, usage) }
+          changes += added_values.map { |value| Changes::EnumValueAdded.new(new_enum, value, usage) }
 
           each_common_value do |old_value, new_value|
             # TODO: Add Directive Stuff
@@ -33,7 +35,7 @@ module GraphQL
 
         private
 
-        attr_reader :old_enum, :new_enum, :old_values, :new_values
+        attr_reader :old_enum, :new_enum, :old_values, :new_values, :usage
 
         def each_common_value(&block)
           intersection = old_values.keys & new_values.keys

--- a/lib/graphql/schema_comparator/diff/schema.rb
+++ b/lib/graphql/schema_comparator/diff/schema.rb
@@ -42,7 +42,7 @@ module GraphQL
           else
             case old_type.kind.name
             when "ENUM"
-              changes += Diff::Enum.new(old_type, new_type).diff
+              changes += Diff::Enum.new(old_type, new_type, enum_usage(new_type)).diff
             when "UNION"
               changes += Diff::Union.new(old_type, new_type).diff
             when "INPUT_OBJECT"
@@ -93,6 +93,12 @@ module GraphQL
         end
 
         private
+
+        def enum_usage(new_enum)
+          input_usage = new_schema.references_to(new_enum).any? { |member| member.is_a?(GraphQL::Schema::Argument) }
+          output_usage = new_schema.references_to(new_enum).any? { |member| member.is_a?(GraphQL::Schema::Field) }
+          EnumUsage.new(input: input_usage, output: output_usage)
+        end
 
         def each_common_type(&block)
           intersection = old_types.keys & new_types.keys

--- a/lib/graphql/schema_comparator/enum_usage.rb
+++ b/lib/graphql/schema_comparator/enum_usage.rb
@@ -1,0 +1,18 @@
+module GraphQL
+  module SchemaComparator
+    class EnumUsage
+      def initialize(input:, output:)
+        @input = input
+        @output = output
+      end
+
+      def input?
+        @input
+      end
+
+      def output?
+        @output
+      end
+    end
+  end
+end

--- a/test/lib/graphql/schema_comparator/changes/enum_value_added_test.rb
+++ b/test/lib/graphql/schema_comparator/changes/enum_value_added_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class GraphQL::SchemaComparator::Changes::EnumValueAddedTest < Minitest::Test
+  class ProgrammingLanguageEnum < GraphQL::Schema::Enum
+    value 'PYTHON'
+    value 'RUBY'
+    value 'JAVASCRIPT'
+  end
+
+  def test_with_input_usage
+    change = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(
+      ProgrammingLanguageEnum,
+      ProgrammingLanguageEnum.values['RUBY'],
+      GraphQL::SchemaComparator::EnumUsage.new(input: true, output: false)
+    )
+
+    assert change.non_breaking?
+  end
+
+  def test_with_output_usage
+    change = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(
+      ProgrammingLanguageEnum,
+      ProgrammingLanguageEnum.values['RUBY'],
+      GraphQL::SchemaComparator::EnumUsage.new(input: false, output: true)
+    )
+
+    assert change.dangerous?
+  end
+end

--- a/test/lib/graphql/schema_comparator/changes/enum_value_removed_test.rb
+++ b/test/lib/graphql/schema_comparator/changes/enum_value_removed_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class GraphQL::SchemaComparator::Changes::EnumValueRemovedTest < Minitest::Test
+  class ProgrammingLanguageEnum < GraphQL::Schema::Enum
+    value 'PYTHON'
+    value 'RUBY'
+    value 'JAVASCRIPT'
+  end
+
+  def test_with_input_usage
+    change = GraphQL::SchemaComparator::Changes::EnumValueRemoved.new(
+      ProgrammingLanguageEnum,
+      ProgrammingLanguageEnum.values['JAVASCRIPT'],
+      GraphQL::SchemaComparator::EnumUsage.new(input: true, output: false)
+    )
+
+    assert change.breaking?
+  end
+
+  def test_with_output_usage
+    change = GraphQL::SchemaComparator::Changes::EnumValueRemoved.new(
+      ProgrammingLanguageEnum,
+      ProgrammingLanguageEnum.values['JAVASCRIPT'],
+      GraphQL::SchemaComparator::EnumUsage.new(input: false, output: true)
+    )
+
+    assert change.non_breaking?
+  end
+end

--- a/test/lib/graphql/schema_comparator/diff/enum_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/enum_test.rb
@@ -18,7 +18,8 @@ class GraphQL::SchemaComparator::Diff::EnumTest < Minitest::Test
       value("CPLUSPLUS", "iamverysmart")
     end
 
-    differ = GraphQL::SchemaComparator::Diff::Enum.new(old_enum, new_enum)
+    usage = GraphQL::SchemaComparator::EnumUsage.new(input: true, output: true)
+    differ = GraphQL::SchemaComparator::Diff::Enum.new(old_enum, new_enum, usage)
 
     assert_equal [
       "Enum value `RUBY` was removed from enum `Languages`",

--- a/test/lib/graphql/schema_comparator/result_test.rb
+++ b/test/lib/graphql/schema_comparator/result_test.rb
@@ -50,7 +50,11 @@ class GraphQL::SchemaComparator::ResultTest < Minitest::Test
   end
 
   def test_breaking_changes
-    enum_value_added = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(EnumType, EnumType.values["foo"])
+    enum_value_added = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(
+      EnumType,
+      EnumType.values["foo"],
+      GraphQL::SchemaComparator::EnumUsage.new(input: true, output: true)
+    )
     field_added = GraphQL::SchemaComparator::Changes::FieldAdded.new(Type, Type.fields["foo"])
     field_removed = GraphQL::SchemaComparator::Changes::FieldRemoved.new(Type, Type.fields["foo"])
     type_description_changed = GraphQL::SchemaComparator::Changes::TypeDescriptionChanged.new(Type, Type)
@@ -66,7 +70,11 @@ class GraphQL::SchemaComparator::ResultTest < Minitest::Test
   end
 
   def test_dangerous_changes
-    enum_value_added = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(EnumType, EnumType.values["foo"])
+    enum_value_added = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(
+      EnumType,
+      EnumType.values["foo"],
+      GraphQL::SchemaComparator::EnumUsage.new(input: false, output: true)
+    )
     field_added = GraphQL::SchemaComparator::Changes::FieldAdded.new(Type, Type.fields["foo"])
     field_removed = GraphQL::SchemaComparator::Changes::FieldRemoved.new(Type, Type.fields["foo"])
     type_description_changed = GraphQL::SchemaComparator::Changes::TypeDescriptionChanged.new(Type, Type)
@@ -78,11 +86,15 @@ class GraphQL::SchemaComparator::ResultTest < Minitest::Test
       type_description_changed
     ])
 
-    assert_equal [field_removed], result.breaking_changes
+    assert_equal [enum_value_added], result.dangerous_changes
   end
 
   def test_non_breaking_changes
-    enum_value_added = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(EnumType, EnumType.values["foo"])
+    enum_value_added = GraphQL::SchemaComparator::Changes::EnumValueAdded.new(
+      EnumType,
+      EnumType.values["foo"],
+      GraphQL::SchemaComparator::EnumUsage.new(input: false, output: true)
+    )
     field_added = GraphQL::SchemaComparator::Changes::FieldAdded.new(Type, Type.fields["foo"])
     field_removed = GraphQL::SchemaComparator::Changes::FieldRemoved.new(Type, Type.fields["foo"])
     type_description_changed = GraphQL::SchemaComparator::Changes::TypeDescriptionChanged.new(Type, Type)


### PR DESCRIPTION
This PR fixes #18 by only flagging enum value additions as breaking if the enum is used in output types and only flagging enum value removals as breaking if the enum is used in input types.

I tried out a different way of testing schema changes in `GraphQL::SchemaComparator::Diff::SchemaTest` that colocates the change path and message and adds testing of the change level. I'm happy to convert the `test_changes_kitchensink` methood to use this pattern too if you want. 