### PR TITLE
Fix breaking change messages for root schema type changes/additions

### DIFF
--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -201,27 +201,27 @@ module GraphQL
         end
       end
 
-      class SchemaRootTypeAdded < AbstractChange
-        attr_reader :new_schema, :root_type, :criticality
+      class RootOperationTypeAdded < AbstractChange
+        attr_reader :new_schema, :operation_type, :criticality
 
-        def initialize(new_schema:, root_type:)
+        def initialize(new_schema:, operation_type:)
           @new_schema = new_schema
-          @root_type = root_type
+          @operation_type = operation_type
           @criticality = Changes::Criticality.non_breaking(
-            reason: "Adding a schema #{root_type} root is considered non-breaking."
+            reason: "Adding a schema #{operation_type} root is considered non-breaking."
           )
         end
 
         def message
-          "Schema #{root_type} root `#{root_type_name}` was added"
+          "Schema #{operation_type} root `#{operation_type_name}` was added"
         end
 
         def path
-          root_type_name
+          operation_type_name
         end
 
-        def root_type_name
-          case root_type
+        def operation_type_name
+          case operation_type
             when :query
               new_schema.query.graphql_name
             when :mutation
@@ -232,26 +232,26 @@ module GraphQL
         end
       end
 
-      class SchemaRootTypeChanged < AbstractChange
-        attr_reader :old_schema, :new_schema, :root_type, :criticality
+      class RootOperationTypeChanged < AbstractChange
+        attr_reader :old_schema, :new_schema, :operation_type, :criticality
 
-        def initialize(old_schema:, new_schema:, root_type:)
+        def initialize(old_schema:, new_schema:, operation_type:)
           @old_schema = old_schema
           @new_schema = new_schema
-          @root_type = root_type
+          @operation_type = operation_type
           @criticality = Changes::Criticality.breaking
         end
 
         def message
-          "Schema #{root_type} root has changed from `#{root_type_name_for_schema(old_schema)}` to `#{root_type_name_for_schema(new_schema)}`"
+          "Schema #{operation_type} root has changed from `#{operation_type_name(old_schema)}` to `#{operation_type_name(new_schema)}`"
         end
 
         def path
-          root_type_name_for_schema(old_schema)
+          operation_type_name(old_schema)
         end
 
-        def root_type_name_for_schema(schema)
-          case root_type
+        def operation_type_name(schema)
+          case operation_type
             when :query
               schema.query.graphql_name
             when :mutation
@@ -262,25 +262,25 @@ module GraphQL
         end
       end
 
-      class SchemaRootTypeRemoved < AbstractChange
-        attr_reader :old_schema, :root_type, :criticality
+      class RootOperationTypeRemoved < AbstractChange
+        attr_reader :old_schema, :operation_type, :criticality
 
-        def initialize(old_schema:, root_type:)
+        def initialize(old_schema:, operation_type:)
           @old_schema = old_schema
-          @root_type = root_type
+          @operation_type = operation_type
           @criticality = Changes::Criticality.breaking
         end
 
         def message
-          "Schema #{root_type} root `#{root_type_name}` was removed"
+          "Schema #{operation_type} root `#{operation_type_name}` was removed"
         end
 
         def path
-          root_type_name
+          operation_type_name
         end
 
-        def root_type_name
-          case root_type
+        def operation_type_name
+          case operation_type
             when :query
               old_schema.query.graphql_name
             when :mutation

--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -226,7 +226,7 @@ module GraphQL
           @old_schema = old_schema
           @new_schema = new_schema
           @criticality = Changes::Criticality.non_breaking(
-            reason: "Adding a schema subscription root is considered non-breaking."
+            reason: "Adding a schema query root is considered non-breaking."
           )
         end
 
@@ -424,26 +424,6 @@ module GraphQL
         end
       end
 
-      class SchemaSubscriptionTypeAdded < AbstractChange
-        attr_reader :old_schema, :new_schema, :criticality
-
-        def initialize(old_schema, new_schema)
-          @old_schema = old_schema
-          @new_schema = new_schema
-          @criticality = Changes::Criticality.non_breaking(
-            reason: "Adding a schema subscription root is considered non-breaking."
-          )
-        end
-
-        def message
-          "Schema subscription root `#{new_schema.subscription.graphql_name}` was added"
-        end
-
-        def path
-          new_schema.subscription&.graphql_name
-        end
-      end
-
       class SchemaMutationTypeChanged < AbstractChange
         attr_reader :old_schema, :new_schema, :criticality
 
@@ -474,11 +454,11 @@ module GraphQL
         end
 
         def message
-          "Schema mutation root `#{new_schema.mutation&.graphql_name}` was added"
+          "Schema mutation root `#{new_schema.mutation.graphql_name}` was added"
         end
 
         def path
-          new_schema.mutation&.graphql_name
+          new_schema.mutation.graphql_name
         end
       end
 
@@ -516,7 +496,7 @@ module GraphQL
         end
 
         def path
-          new_schema.subscription&.graphql_name
+          new_schema.subscription.graphql_name
         end
       end
 

--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -215,7 +215,27 @@ module GraphQL
         end
 
         def path
-          # TODO
+          new_schema.query.graphql_name
+        end
+      end
+
+      class SchemaQueryTypeAdded < AbstractChange
+        attr_reader :old_schema, :new_schema, :criticality
+
+        def initialize(old_schema, new_schema)
+          @old_schema = old_schema
+          @new_schema = new_schema
+          @criticality = Changes::Criticality.non_breaking(
+            reason: "Adding a schema subscription root is considered non-breaking."
+          )
+        end
+
+        def message
+          "Schema query root `#{new_schema.query&.graphql_name}` was added."
+        end
+
+        def path
+          new_schema.query&.graphql_name
         end
       end
 
@@ -404,6 +424,26 @@ module GraphQL
         end
       end
 
+      class SchemaSubscriptionTypeAdded < AbstractChange
+        attr_reader :old_schema, :new_schema, :criticality
+
+        def initialize(old_schema, new_schema)
+          @old_schema = old_schema
+          @new_schema = new_schema
+          @criticality = Changes::Criticality.non_breaking(
+            reason: "Adding a schema subscription root is considered non-breaking."
+          )
+        end
+
+        def message
+          "Schema subscription root `#{new_schema.subscription.graphql_name}` was added"
+        end
+
+        def path
+          new_schema.subscription&.graphql_name
+        end
+      end
+
       class SchemaMutationTypeChanged < AbstractChange
         attr_reader :old_schema, :new_schema, :criticality
 
@@ -414,11 +454,31 @@ module GraphQL
         end
 
         def message
-          "Schema mutation root has changed from `#{old_schema.mutation}` to `#{new_schema.mutation}`"
+          "Schema mutation root has changed from `#{old_schema.mutation.graphql_name}` to `#{new_schema.mutation&.graphql_name}`"
         end
 
         def path
-          # TODO
+          old_schema.mutation.graphql_name
+        end
+      end
+
+      class SchemaMutationTypeAdded < AbstractChange
+        attr_reader :old_schema, :new_schema, :criticality
+
+        def initialize(old_schema, new_schema)
+          @old_schema = old_schema
+          @new_schema = new_schema
+          @criticality = Changes::Criticality.non_breaking(
+            reason: "Adding a schema mutation root is considered non-breaking."
+          )
+        end
+
+        def message
+          "Schema mutation root `#{new_schema.mutation&.graphql_name}` was added"
+        end
+
+        def path
+          new_schema.mutation&.graphql_name
         end
       end
 
@@ -432,11 +492,31 @@ module GraphQL
         end
 
         def message
-          "Schema subscription type has changed from `#{old_schema.subscription}` to `#{new_schema.subscription}`"
+          "Schema subscription type has changed from `#{old_schema.subscription.graphql_name}` to `#{new_schema.subscription.graphql_name}`"
         end
 
         def path
-          # TODO
+          old_schema.subscription.graphql_name
+        end
+      end
+
+      class SchemaSubscriptionTypeAdded < AbstractChange
+        attr_reader :old_schema, :new_schema, :criticality
+
+        def initialize(old_schema, new_schema)
+          @old_schema = old_schema
+          @new_schema = new_schema
+          @criticality = Changes::Criticality.non_breaking(
+            reason: "Adding a schema subscription root is considered non-breaking."
+          )
+        end
+
+        def message
+          "Schema subscription root `#{new_schema.subscription.graphql_name}` was added"
+        end
+
+        def path
+          new_schema.subscription&.graphql_name
         end
       end
 
@@ -457,11 +537,11 @@ module GraphQL
         end
 
         def message
-          if old_argument.default_value.nil? || old_argument.default_value == :__no_default__
-            "Default value `#{new_argument.default_value}` was added to argument `#{new_argument.graphql_name}` on field `#{field.path}`"
-          else
+          if old_argument.default_value?
             "Default value for argument `#{new_argument.graphql_name}` on field `#{field.path}` changed"\
               " from `#{old_argument.default_value}` to `#{new_argument.default_value}`"
+          else
+            "Default value `#{new_argument.default_value}` was added to argument `#{new_argument.graphql_name}` on field `#{field.path}`"
           end
         end
 
@@ -507,8 +587,12 @@ module GraphQL
         end
 
         def message
-          "Default value for argument `#{new_argument.graphql_name}` on directive `#{directive.graphql_name}` changed"\
-            " from `#{old_argument.default_value}` to `#{new_argument.default_value}`"
+          if old_argument.default_value?
+            "Default value for argument `#{new_argument.graphql_name}` on directive `#{directive.graphql_name}` changed"\
+              " from `#{old_argument.default_value}` to `#{new_argument.default_value}`"
+          else
+            "Default value `#{new_argument.default_value}` was added to argument `#{new_argument.graphql_name}` on directive `#{directive.graphql_name}`"
+          end
         end
 
         def path

--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -211,11 +211,11 @@ module GraphQL
         end
 
         def message
-          "Schema query root has changed from `#{old_schema.query.graphql_name}` to `#{new_schema.query.graphql_name}`"
+          "Schema query root has changed from `#{old_schema.query.graphql_name}` to `#{new_schema.query&.graphql_name}`"
         end
 
         def path
-          new_schema.query.graphql_name
+          new_schema.query&.graphql_name
         end
       end
 
@@ -231,11 +231,11 @@ module GraphQL
         end
 
         def message
-          "Schema query root `#{new_schema.query&.graphql_name}` was added."
+          "Schema query root `#{new_schema.query.graphql_name}` was added."
         end
 
         def path
-          new_schema.query&.graphql_name
+          new_schema.query.graphql_name
         end
       end
 
@@ -472,7 +472,7 @@ module GraphQL
         end
 
         def message
-          "Schema subscription type has changed from `#{old_schema.subscription.graphql_name}` to `#{new_schema.subscription.graphql_name}`"
+          "Schema subscription type has changed from `#{old_schema.subscription.graphql_name}` to `#{new_schema.subscription&.graphql_name}`"
         end
 
         def path

--- a/lib/graphql/schema_comparator/diff/schema.rb
+++ b/lib/graphql/schema_comparator/diff/schema.rb
@@ -66,31 +66,31 @@ module GraphQL
 
           if old_schema.query&.graphql_name != new_schema.query&.graphql_name
             if old_schema.query.nil?
-              changes << Changes::SchemaRootTypeAdded.new(new_schema: new_schema, root_type: :query)
+              changes << Changes::RootOperationTypeAdded.new(new_schema: new_schema, operation_type: :query)
             elsif new_schema.query.nil?
-              changes << Changes::SchemaRootTypeRemoved.new(old_schema: old_schema, root_type: :query)
+              changes << Changes::RootOperationTypeRemoved.new(old_schema: old_schema, operation_type: :query)
             else
-              changes << Changes::SchemaRootTypeChanged.new(old_schema: old_schema, new_schema: new_schema, root_type: :query)
+              changes << Changes::RootOperationTypeChanged.new(old_schema: old_schema, new_schema: new_schema, operation_type: :query)
             end
           end
 
           if old_schema.mutation&.graphql_name != new_schema.mutation&.graphql_name
             if old_schema.mutation.nil?
-              changes << Changes::SchemaRootTypeAdded.new(new_schema: new_schema, root_type: :mutation)
+              changes << Changes::RootOperationTypeAdded.new(new_schema: new_schema, operation_type: :mutation)
             elsif new_schema.mutation.nil?
-              changes << Changes::SchemaRootTypeRemoved.new(old_schema: old_schema, root_type: :mutation)
+              changes << Changes::RootOperationTypeRemoved.new(old_schema: old_schema, operation_type: :mutation)
             else
-              changes << Changes::SchemaRootTypeChanged.new(old_schema: old_schema, new_schema: new_schema, root_type: :mutation)
+              changes << Changes::RootOperationTypeChanged.new(old_schema: old_schema, new_schema: new_schema, operation_type: :mutation)
             end
           end
 
           if old_schema.subscription&.graphql_name != new_schema.subscription&.graphql_name
             if old_schema.subscription.nil?
-              changes << Changes::SchemaRootTypeAdded.new(new_schema: new_schema, root_type: :subscription)
+              changes << Changes::RootOperationTypeAdded.new(new_schema: new_schema, operation_type: :subscription)
             elsif new_schema.subscription.nil?
-              changes << Changes::SchemaRootTypeRemoved.new(old_schema: old_schema, root_type: :subscription)
+              changes << Changes::RootOperationTypeRemoved.new(old_schema: old_schema, operation_type: :subscription)
             else
-              changes << Changes::SchemaRootTypeChanged.new(old_schema: old_schema, new_schema: new_schema, root_type: :subscription)
+              changes << Changes::RootOperationTypeChanged.new(old_schema: old_schema, new_schema: new_schema, operation_type: :subscription)
             end
           end
 

--- a/lib/graphql/schema_comparator/diff/schema.rb
+++ b/lib/graphql/schema_comparator/diff/schema.rb
@@ -65,15 +65,27 @@ module GraphQL
           changes = []
 
           if old_schema.query&.graphql_name != new_schema.query&.graphql_name
-            changes << Changes::SchemaQueryTypeChanged.new(old_schema, new_schema)
+            if old_schema.query
+              changes << Changes::SchemaQueryTypeChanged.new(old_schema, new_schema)
+            else
+              changes << Changes::SchemaQueryTypeAdded.new(old_schema, new_schema)
+            end
           end
 
           if old_schema.mutation&.graphql_name != new_schema.mutation&.graphql_name
-            changes << Changes::SchemaMutationTypeChanged.new(old_schema, new_schema)
+            if old_schema.mutation
+              changes << Changes::SchemaMutationTypeChanged.new(old_schema, new_schema)
+            else
+              changes << Changes::SchemaMutationTypeAdded.new(old_schema, new_schema)
+            end
           end
 
           if old_schema.subscription&.graphql_name != new_schema.subscription&.graphql_name
-            changes << Changes::SchemaSubscriptionTypeChanged.new(old_schema, new_schema)
+            if old_schema.subscription
+              changes << Changes::SchemaSubscriptionTypeChanged.new(old_schema, new_schema)
+            else
+              changes << Changes::SchemaSubscriptionTypeAdded.new(old_schema, new_schema)
+            end
           end
 
           changes

--- a/lib/graphql/schema_comparator/diff/schema.rb
+++ b/lib/graphql/schema_comparator/diff/schema.rb
@@ -65,26 +65,32 @@ module GraphQL
           changes = []
 
           if old_schema.query&.graphql_name != new_schema.query&.graphql_name
-            if old_schema.query
-              changes << Changes::SchemaQueryTypeChanged.new(old_schema, new_schema)
+            if old_schema.query.nil?
+              changes << Changes::SchemaRootTypeAdded.new(new_schema: new_schema, root_type: :query)
+            elsif new_schema.query.nil?
+              changes << Changes::SchemaRootTypeRemoved.new(old_schema: old_schema, root_type: :query)
             else
-              changes << Changes::SchemaQueryTypeAdded.new(old_schema, new_schema)
+              changes << Changes::SchemaRootTypeChanged.new(old_schema: old_schema, new_schema: new_schema, root_type: :query)
             end
           end
 
           if old_schema.mutation&.graphql_name != new_schema.mutation&.graphql_name
-            if old_schema.mutation
-              changes << Changes::SchemaMutationTypeChanged.new(old_schema, new_schema)
+            if old_schema.mutation.nil?
+              changes << Changes::SchemaRootTypeAdded.new(new_schema: new_schema, root_type: :mutation)
+            elsif new_schema.mutation.nil?
+              changes << Changes::SchemaRootTypeRemoved.new(old_schema: old_schema, root_type: :mutation)
             else
-              changes << Changes::SchemaMutationTypeAdded.new(old_schema, new_schema)
+              changes << Changes::SchemaRootTypeChanged.new(old_schema: old_schema, new_schema: new_schema, root_type: :mutation)
             end
           end
 
           if old_schema.subscription&.graphql_name != new_schema.subscription&.graphql_name
-            if old_schema.subscription
-              changes << Changes::SchemaSubscriptionTypeChanged.new(old_schema, new_schema)
+            if old_schema.subscription.nil?
+              changes << Changes::SchemaRootTypeAdded.new(new_schema: new_schema, root_type: :subscription)
+            elsif new_schema.subscription.nil?
+              changes << Changes::SchemaRootTypeRemoved.new(old_schema: old_schema, root_type: :subscription)
             else
-              changes << Changes::SchemaSubscriptionTypeAdded.new(old_schema, new_schema)
+              changes << Changes::SchemaRootTypeChanged.new(old_schema: old_schema, new_schema: new_schema, root_type: :subscription)
             end
           end
 

--- a/test/lib/graphql/schema_comparator/diff/schema_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/schema_test.rb
@@ -411,7 +411,6 @@ class GraphQL::SchemaComparator::Diff::SchemaTest < Minitest::Test
   end
 
   def normalize_schema_diff(changes)
-    puts changes
     changes.sort_by { |changes| [changes[:path], changes[:message], changes[:level]] }
   end
 end

--- a/test/lib/graphql/schema_comparator/diff/schema_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/schema_test.rb
@@ -5,6 +5,7 @@ class GraphQL::SchemaComparator::Diff::SchemaTest < Minitest::Test
     @old_schema = <<~SCHEMA
       schema {
         query: Query
+        mutation: OldMutation
       }
       input AInput {
         # a
@@ -67,6 +68,9 @@ class GraphQL::SchemaComparator::Diff::SchemaTest < Minitest::Test
       type WillBeRemoved {
         a: String
       }
+      type OldMutation {
+        a: String!
+      }
 
       directive @willBeRemoved on FIELD
     SCHEMA
@@ -74,6 +78,7 @@ class GraphQL::SchemaComparator::Diff::SchemaTest < Minitest::Test
     @new_schema =<<~SCHEMA
       schema {
         query: Query
+        mutation: Mutation
       }
       input AInput {
         # changed
@@ -139,6 +144,10 @@ class GraphQL::SchemaComparator::Diff::SchemaTest < Minitest::Test
         # Included when true.
         someArg: String!
       ) on FIELD
+
+      type Mutation {
+        a: String!
+      }
     SCHEMA
 
     @differ = GraphQL::SchemaComparator::Diff::Schema.new(
@@ -168,7 +177,7 @@ class GraphQL::SchemaComparator::Diff::SchemaTest < Minitest::Test
       "Deprecation reason on field `CType.a` has changed from `whynot` to `cuz`",
       "Argument `arg: Int` added to field `CType.a`",
       "Default value `10` was added to argument `arg` on field `CType.d`",
-      "Default value for argument `anotherArg` on directive `yolo` changed from `__no_default__` to `Test`",
+      "Default value `Test` was added to argument `anotherArg` on directive `yolo`",
       "Union member `BType` was removed from Union type `MyUnion`",
       "Union member `DType` was added to Union type `MyUnion`",
       "Field `anotherInterfaceField` was removed from object type `AnotherInterface`",
@@ -192,6 +201,9 @@ class GraphQL::SchemaComparator::Diff::SchemaTest < Minitest::Test
       "Argument `willBeRemoved` was removed from directive `yolo`",
       "Description for argument `someArg` on directive `yolo` changed from `Included when true.` to `someArg does stuff`",
       "Type for argument `someArg` on directive `yolo` changed from `Boolean!` to `String!`",
+      "Type `Mutation` was added",
+      "Type `OldMutation` was removed",
+      "Schema mutation root has changed from `OldMutation` to `Mutation`",
     ].sort, @differ.diff.map(&:message).sort
 
     assert_equal [
@@ -214,8 +226,11 @@ class GraphQL::SchemaComparator::Diff::SchemaTest < Minitest::Test
       "CType.a.arg",
       "CType.d.arg",
       "CType.interfaceField",
+      "Mutation",
       "MyUnion",
       "MyUnion",
+      "OldMutation",
+      "OldMutation",
       "AnotherInterface.anotherInterfaceField",
       "AnotherInterface.b",
       "WithInterfaces",
@@ -239,6 +254,48 @@ class GraphQL::SchemaComparator::Diff::SchemaTest < Minitest::Test
       "@yolo.someArg",
       "@yolo.anotherArg",
     ].sort, @differ.diff.map(&:path).sort
+  end
+
+  def test_schema_changes
+    old_schema = <<~SCHEMA
+      schema {
+        query: Query
+      }
+
+      type Query {
+        a: String!
+      }
+    SCHEMA
+
+    new_schema = <<~SCHEMA
+      schema {
+        query: Query
+        mutation: Mutation
+        subscription: Subscription
+      }
+
+      type Query {
+        a: String!
+      }
+
+      type Mutation {
+        a: String!
+      }
+
+      type Subscription {
+        a: String!
+      }
+    SCHEMA
+
+    expected_changes = [
+      { path: "Mutation", message: "Schema mutation root `Mutation` was added", level: 1 },
+      { path: "Mutation", message: "Type `Mutation` was added", level: 1 },
+      { path: "Subscription", message: "Schema subscription root `Subscription` was added", level: 1 },
+      { path: "Subscription", message: "Type `Subscription` was added", level: 1 },
+    ]
+
+    actual_changes = schema_diff(old_schema, new_schema)
+    assert_equal(normalize_schema_diff(expected_changes), normalize_schema_diff(actual_changes))
   end
 
   def test_enum_value_changes
@@ -354,6 +411,7 @@ class GraphQL::SchemaComparator::Diff::SchemaTest < Minitest::Test
   end
 
   def normalize_schema_diff(changes)
+    puts changes
     changes.sort_by { |changes| [changes[:path], changes[:message], changes[:level]] }
   end
 end

--- a/test/lib/graphql/schema_comparator/diff/schema_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/schema_test.rb
@@ -256,13 +256,18 @@ class GraphQL::SchemaComparator::Diff::SchemaTest < Minitest::Test
     ].sort, @differ.diff.map(&:path).sort
   end
 
-  def test_schema_changes
+  def test_schema_root_changes
     old_schema = <<~SCHEMA
       schema {
-        query: Query
+        query: OldQuery
+        mutation: Mutation
       }
 
-      type Query {
+      type OldQuery {
+        a: String!
+      }
+
+      type Mutation {
         a: String!
       }
     SCHEMA
@@ -270,15 +275,10 @@ class GraphQL::SchemaComparator::Diff::SchemaTest < Minitest::Test
     new_schema = <<~SCHEMA
       schema {
         query: Query
-        mutation: Mutation
         subscription: Subscription
       }
 
       type Query {
-        a: String!
-      }
-
-      type Mutation {
         a: String!
       }
 
@@ -288,8 +288,11 @@ class GraphQL::SchemaComparator::Diff::SchemaTest < Minitest::Test
     SCHEMA
 
     expected_changes = [
-      { path: "Mutation", message: "Schema mutation root `Mutation` was added", level: 1 },
-      { path: "Mutation", message: "Type `Mutation` was added", level: 1 },
+      { path: "Mutation", message: "Schema mutation root `Mutation` was removed", level: 3 },
+      { path: "Mutation", message: "Type `Mutation` was removed", level: 3 },
+      { path: "OldQuery", message: "Schema query root has changed from `OldQuery` to `Query`", level: 3 },
+      { path: "OldQuery", message: "Type `OldQuery` was removed", level: 3 },
+      { path: "Query", message: "Type `Query` was added", level: 1 },
       { path: "Subscription", message: "Schema subscription root `Subscription` was added", level: 1 },
       { path: "Subscription", message: "Type `Subscription` was added", level: 1 },
     ]


### PR DESCRIPTION
As part of our work using graphql-schema_comparator, we've been using the schema comparator in our test suite to add visibility to when developers propose breaking changes to our schema. Recently, we added a mutation root type to a schema that previous didn't have one, and were surprised to see that as a breaking change, and to see the breaking change message using a string representation of the mutation root type itself (meaning that the message itself was not a stable description of the change, but would change every time our test was run):

> Schema mutation root has changed from `` to `#<Class:0x00007fd9879d8858>`

This PR does two things:
- It adds new non-breaking changes for when root schema types (query, mutation, subscription) are added
- Modifies the descriptions of the query/mutation/subscription type _changed_ changes to refer to the `graphql_name`s of the types, rather than a string representation of the type class, and
- Fixes another error that was causing the tests to fail, around the names of default values for arguments