### PR TITLE
Add support for `path` on `DirectiveArgumentAdded`.

### DIFF
--- a/lib/graphql/schema_comparator/changes.rb
+++ b/lib/graphql/schema_comparator/changes.rb
@@ -1086,6 +1086,10 @@ module GraphQL
         def message
           "Argument `#{argument.graphql_name}` was added to directive `#{directive.graphql_name}`"
         end
+
+        def path
+          ["@#{directive.graphql_name}", argument.graphql_name].join('.')
+        end
       end
     end
   end

--- a/test/lib/graphql/schema_comparator/diff/directive_test.rb
+++ b/test/lib/graphql/schema_comparator/diff/directive_test.rb
@@ -27,5 +27,15 @@ class GraphQL::SchemaComparator::Diff::DirectiveTest < Minitest::Test
       "Default value for argument `a` on directive `Default` changed from `No` to `Yes`",
       "Type for argument `a` on directive `Default` changed from `Int!` to `String!`"
     ], differ.diff.map(&:message)
+
+    assert_equal [
+      "@Default",
+      "@Default",
+      "@Default.c",
+      "@Default.b",
+      "@Default.a",
+      "@Default.a",
+      "@Default.a"
+    ], differ.diff.map(&:path)
   end
 end


### PR DESCRIPTION
Adds an implementation of `path` on `DirectiveArgumentAdded`.

I couldn't figure out what the best way to add a test for this is, but happy to add one.